### PR TITLE
Permission to access uxp config configmap

### DIFF
--- a/cluster/charts/universal-crossplane/templates/upbound-agent/role.yaml
+++ b/cluster/charts/universal-crossplane/templates/upbound-agent/role.yaml
@@ -1,3 +1,39 @@
+{{- if or (eq .Values.upbound.controlPlane.permission "view") (eq .Values.upbound.controlPlane.permission "edit") }}
+---
+# We need to be able to read universal-crossplane-config configmap in the namespace
+# where UXP is deployed to provide version/configuration information.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "agent-name" . }}-uxp-config
+  labels:
+    {{- include "labelsAgent" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["universal-crossplane-config"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "agent-name" . }}-uxp-config
+  labels:
+    {{- include "labelsAgent" . | nindent 4 }}
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: upbound:view
+{{- if eq .Values.upbound.controlPlane.permission "edit" }}
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: upbound:edit
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "agent-name" . }}-uxp-config
+{{- end }}
 {{- if eq .Values.upbound.controlPlane.permission "edit" }}
 ---
 # We need to be able to manage Secrets in the namespace where UXP is deployed

--- a/cluster/local/config/validation/validate.sh
+++ b/cluster/local/config/validation/validate.sh
@@ -35,6 +35,10 @@ ${CP_KUBECTL} -n ${HELM_RELEASE_NAMESPACE} create secret generic "${validation_s
 ${KUBECTL} -n ${HELM_RELEASE_NAMESPACE} get secret "${validation_secret}"
 echo_info "Successfully validated \"kubectl\" queries over Upbound Cloud!"
 
+echo_info "Validating reading universal crossplane configuration works..."
+${CP_KUBECTL} -n ${HELM_RELEASE_NAMESPACE} get cm universal-crossplane-config -o yaml
+echo_info "Successfully validated reading universal crossplane configuration!"
+
 echo_info "Validating \"xqgl\" queries work over Upbound Cloud..."
 # shellcheck disable=SC2089
 query='query {


### PR DESCRIPTION
With the deprecation of `crossplane-graphql`, `upbound-agent`'s service account will need to access to `universal-crossplane-configmap` which is being used by `xgql`.

Signed-off-by: Hasan Turken <turkenh@gmail.com>