### PR TITLE
Make crossplane pull policy IfNotPresent

### DIFF
--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -7,7 +7,7 @@ deploymentStrategy: RollingUpdate
 image:
   repository: crossplane/crossplane
   tag: %%CROSSPLANE_TAG%%
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 nodeSelector: {}
 tolerations: {}


### PR DESCRIPTION
Changes crossplane pull policy from Always to IfNotPresent to match
other charts and upstream Crossplane.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follows https://github.com/crossplane/crossplane/pull/2271