### PR TITLE
Wait for UXP to get ready before validation

### DIFF
--- a/cluster/local/config/validation/validate.sh
+++ b/cluster/local/config/validation/validate.sh
@@ -26,7 +26,12 @@ ${CP_KUBECTL} config set-context "self-hosted-test" --cluster="self-hosted-test"
 ${CP_KUBECTL} config use-context "self-hosted-test"
 
 echo_info "Validating \"kubectl\" queries work over Upbound Cloud..."
-${CP_KUBECTL} get ns
+
+for i in {1..10}; do
+  ${CP_KUBECTL} get ns && break || sleep 10;
+  echo "UXP may not be ready yet, retrying..."
+done
+
 validation_secret="uxp-validation"
 ${CP_KUBECTL} -n ${HELM_RELEASE_NAMESPACE} delete secret "${validation_secret}" --ignore-not-found
 ${CP_KUBECTL} -n ${HELM_RELEASE_NAMESPACE} create secret generic "${validation_secret}" --from-literal=foo=bar


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->


With [the removal of liveness/readiness probes of agent](https://github.com/upbound/universal-crossplane/issues/74), we might be starting validation too quick which causes sporadic failures. This PR aims to fix this by adding a retry for the first kubectl query running against UXP.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

make e2e.run
