### PR TITLE
Make edit permission level default and add post-installation message

### DIFF
--- a/cluster/charts/universal-crossplane/templates/NOTES.txt
+++ b/cluster/charts/universal-crossplane/templates/NOTES.txt
@@ -1,7 +1,7 @@
-By proceeding, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.pdf
+By proceeding, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html
 
 ✨ Thank you for installing Universal Crossplane!
-{{ if or (eq .Values.upbound.controlPlane.permission "view") (eq .Values.upbound.controlPlane.permission "edit") }}
+{{- if or (eq .Values.upbound.controlPlane.permission "view") (eq .Values.upbound.controlPlane.permission "edit") }}
 🚀 You can now connect your cluster to Upbound Cloud!
 
 Example command:

--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -82,7 +82,7 @@ upbound:
   apiURL: "https://api.upbound.io"
   connectHost: "connect.upbound.io"
   controlPlane:
-    permission: None
+    permission: edit
     tokenSecretName: upbound-control-plane-token
     token: ""
 


### PR DESCRIPTION
### Description of your changes

We now support the mode where token secret does not exist before the installation. In order to provide a friction-less experience for connecting to UbC, `edit` permission mode is made default and necessary commands are added in post-installation Helm message.

I added link to Upbound Software License Agreement as well.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```console
$ helm install universal-crossplane --namespace upbound-system cluster/charts/universal-crossplane
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable" via:
WARNING: helm repo add "stable" "https://charts.helm.sh/stable" --force-update
NAME: universal-crossplane
LAST DEPLOYED: Sat May  8 02:56:46 2021
NAMESPACE: upbound-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
By proceeding, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.pdf

✨ Thank you for installing Universal Crossplane!
🚀 You can now connect your cluster to Upbound Cloud!

Example command:

$ up cloud controlplane attach <control plane name> | \
up uxp connect --token-secret-name upbound-control-plane-token --namespace upbound-system -
```
