### PR TITLE
Remove credentials for accessing private dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,6 @@ jobs:
         with:
           submodules: true
 
-      # TODO(turkenh): remove once there is no private dependency (e.g. nats-proxy)
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/upbound".insteadOf "https://github.com/upbound"
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -99,11 +94,6 @@ jobs:
         with:
           submodules: true
 
-      # TODO(turkenh): remove once there is no private dependency (e.g. nats-proxy)
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/upbound".insteadOf "https://github.com/upbound"
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -143,11 +133,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-
-      # TODO(turkenh): remove once there is no private dependency (e.g. nats-proxy)
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/upbound".insteadOf "https://github.com/upbound"
 
       - name: Fetch History
         run: git fetch --prune --unshallow
@@ -208,11 +193,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-
-      # TODO(turkenh): remove once there is no private dependency (e.g. nats-proxy)
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/upbound".insteadOf "https://github.com/upbound"
 
       - name: Fetch History
         run: git fetch --prune --unshallow

--- a/.github/workflows/pushvalidation.yml
+++ b/.github/workflows/pushvalidation.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           submodules: true
 
-      # TODO(turkenh): remove once there is no private dependency (e.g. nats-proxy)
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/upbound".insteadOf "https://github.com/upbound"
-
       - name: Fetch History
         run: git fetch --prune --unshallow
 


### PR DESCRIPTION


### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->


Now that UXP and all dependencies are open source, we no longer need
credentials to access private dependencies.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Keeping in draft until repo is open sourced.