### PR TITLE
[localdev] Only delete Control plane if token provided 

### DIFF
--- a/cluster/local/config/validation/deploy.sh
+++ b/cluster/local/config/validation/deploy.sh
@@ -9,7 +9,7 @@ fi
 
 source "${scriptdir}/validate.sh"
 
-if [ "${LOCALDEV_CONNECT_CLEANUP}" == "true" ]; then
+if [ "${LOCALDEV_CONNECT_CLEANUP}" == "true" ] && [ -n "${LOCALDEV_CONNECT_API_TOKEN}" ]; then
   echo "Deleting self hosted control plane with id ${CONTROL_PLANE_ID}"
   "${UP}" cloud xp delete --profile=uxp-e2e "${CONTROL_PLANE_ID}"
 fi


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

We try to delete control plane if `LOCALDEV_CONNECT_CLEANUP` but `LOCALDEV_CONNECT_API_TOKEN` not provider, which fails push validations.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
push validation