### PR TITLE
Point to provider-aws on upbound registry for getting started

### DIFF
--- a/docs/getting-started/configuration/crossplane.yaml
+++ b/docs/getting-started/configuration/crossplane.yaml
@@ -8,5 +8,5 @@ spec:
   crossplane:
     version: ">=v1.2.1"
   dependsOn:
-    - provider: crossplane/provider-aws
+    - provider: registry.upbound.io/crossplane/provider-aws
       version: "v0.18.1"


### PR DESCRIPTION


### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

Updates getting-started configuration package to point to provider-aws
dependency in upbound registry.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

**NOTE: package needs to be manually rebuilt and pushed for now**
