### PR TITLE
Expose UXP version in versions ConfigMap

### DIFF
--- a/cluster/charts/universal-crossplane/templates/bootstrapper/versions-configmap.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/versions-configmap.yaml
@@ -8,3 +8,4 @@ data:
   crossplaneVersion: {{ (trimPrefix "v" .Values.image.tag) }}
   xgqlVersion: {{ (trimPrefix "v" .Values.xgql.image.tag) }}
   agentVersion: {{ (trimPrefix "v" .Values.agent.image.tag) }}
+  uxpVersion: {{ .Chart.Version }}


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds the UXP version to the versions ConfigMap so that consumers of the
chart can obtain information about all components from a single
location.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #133 

**NOTE: I have opted to also backport to `release-1.2` as it is a non-breaking change that provides useful functionality on that branch.**

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

`make build` with the change included, then `helm template` on the chart returned:

```yaml
# Source: universal-crossplane/templates/bootstrapper/versions-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: universal-crossplane-config
  labels:
    helm.sh/chart: universal-crossplane-1.3.0-up.1.rc.1.18-gbec8c5c-dirty
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "1.3.0-up.1.rc.1.18-gbec8c5c-dirty"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: bootstrapper
data:
  crossplaneVersion: 1.2.1
  xgqlVersion: 0.1.3
  agentVersion: 1.3.0-up.1.rc.1.18-gbec8c5c-dirty
  uxpVersion: 1.3.0-up.1.rc.1.18-gbec8c5c-dirty
```
