### PR TITLE
Remove ineffectual targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,6 @@ olm.artifacts: olm.build
 
 build.artifacts: olm.artifacts
 
-helm.prepare: generate-chart
-
 generate.run: helm.prepare olm.build
 
 local-dev: $(UP) local.up local.deploy.$(PACKAGE_NAME)
@@ -160,4 +158,4 @@ local-dev: $(UP) local.up local.deploy.$(PACKAGE_NAME)
 e2e.run: build local-dev local.deploy.validation
 e2e.done: local.down
 
-.PHONY: generate-chart olm.build olm.artifacts crossplane submodules fallthrough
+.PHONY: olm.build olm.artifacts crossplane submodules fallthrough


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Due to the merge order of #138 and #139, a few ineffectual make targets
were re-introduced, namely generate-chart, which no longer provides any
functionality.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

**^ This is going to be manually backported as part of #142**

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

`make reviewable`
`make build`