### PR TITLE
Rename remaining gateways as agent

### DIFF
--- a/cmd/upbound-agent/main.go
+++ b/cmd/upbound-agent/main.go
@@ -92,7 +92,7 @@ func main() { // nolint:gocyclo
 	}
 
 	upClient := upbound.NewClient(a.UpboundAPIEndpoint, log, cli.Debug, cli.Agent.Insecure)
-	pubCerts, err := upClient.GetGatewayCerts(token)
+	pubCerts, err := upClient.GetAgentCerts(token)
 	if err != nil {
 		ctx.FatalIfErrorf(errors.Wrap(err, "failed to fetch public certs"))
 	}

--- a/internal/clients/upbound/mocks/upbound.go
+++ b/internal/clients/upbound/mocks/upbound.go
@@ -63,17 +63,17 @@ func (mr *MockClientMockRecorder) FetchNewJWTToken(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNewJWTToken", reflect.TypeOf((*MockClient)(nil).FetchNewJWTToken), arg0, arg1, arg2)
 }
 
-// GetGatewayCerts mocks base method.
-func (m *MockClient) GetGatewayCerts(arg0 string) (upbound.PublicCerts, error) {
+// GetAgentCerts mocks base method.
+func (m *MockClient) GetAgentCerts(arg0 string) (upbound.PublicCerts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGatewayCerts", arg0)
+	ret := m.ctrl.Call(m, "GetAgentCerts", arg0)
 	ret0, _ := ret[0].(upbound.PublicCerts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetGatewayCerts indicates an expected call of GetGatewayCerts.
-func (mr *MockClientMockRecorder) GetGatewayCerts(arg0 interface{}) *gomock.Call {
+// GetAgentCerts indicates an expected call of GetAgentCerts.
+func (mr *MockClientMockRecorder) GetAgentCerts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGatewayCerts", reflect.TypeOf((*MockClient)(nil).GetGatewayCerts), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentCerts", reflect.TypeOf((*MockClient)(nil).GetAgentCerts), arg0)
 }

--- a/internal/clients/upbound/upbound.go
+++ b/internal/clients/upbound/upbound.go
@@ -31,7 +31,7 @@ type PublicCerts struct {
 // Client is the client for upbound api
 //go:generate go run github.com/golang/mock/mockgen -copyright_file ../../../hack/boilerplate.txt -destination ./mocks/upbound.go -package mocks github.com/upbound/universal-crossplane/internal/clients/upbound Client
 type Client interface {
-	GetGatewayCerts(cpToken string) (PublicCerts, error)
+	GetAgentCerts(cpToken string) (PublicCerts, error)
 	FetchNewJWTToken(cpToken, clusterID, publicKey string) (string, error)
 }
 
@@ -78,22 +78,22 @@ func NewClient(host string, log logging.Logger, debug, insecure bool) Client {
 	}
 }
 
-// GetGatewayCerts function returns public certificates to interact with Upbound Cloud.
-func (c *client) GetGatewayCerts(cpToken string) (PublicCerts, error) {
+// GetAgentCerts function returns public certificates to interact with Upbound Cloud.
+func (c *client) GetAgentCerts(cpToken string) (PublicCerts, error) {
 	req := c.resty.R()
 	req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", cpToken))
 
 	resp, err := req.Get(gwCertsPath)
 	if err != nil {
-		return PublicCerts{}, errors.Wrap(err, "failed to request gateway certs")
+		return PublicCerts{}, errors.Wrap(err, "failed to request agent certs")
 	}
 	if resp.StatusCode() != http.StatusOK {
-		return PublicCerts{}, errors.Errorf("gateway certs request failed with %s - %s", resp.Status(), string(resp.Body()))
+		return PublicCerts{}, errors.Errorf("agent certs request failed with %s - %s", resp.Status(), string(resp.Body()))
 	}
 	respBody := map[string]string{}
 
 	if err := json.Unmarshal(resp.Body(), &respBody); err != nil {
-		return PublicCerts{}, errors.Wrap(err, "failed to unmarshall gw certs response")
+		return PublicCerts{}, errors.Wrap(err, "failed to unmarshall agent certs response")
 	}
 	j := respBody[keyJWTPublicKey]
 	n := respBody[keyNATSCA]

--- a/internal/clients/upbound/upbound_test.go
+++ b/internal/clients/upbound/upbound_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Test_GetGatewayCerts(t *testing.T) {
+func Test_GetAgentCerts(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	endpoint := "https://foo.com"
@@ -70,7 +70,7 @@ func Test_GetGatewayCerts(t *testing.T) {
 				responseBody: "some-error",
 			},
 			want: want{
-				err: errors.New("gateway certs request failed with 500 - \"some-error\""),
+				err: errors.New("agent certs request failed with 500 - \"some-error\""),
 			},
 		},
 		"UnexpectedResponseBody": {
@@ -79,7 +79,7 @@ func Test_GetGatewayCerts(t *testing.T) {
 				responseBody: "test-ca",
 			},
 			want: want{
-				err: errors.WithStack(errors.New("failed to unmarshall gw certs response: json: cannot unmarshal string into Go value of type map[string]string")),
+				err: errors.WithStack(errors.New("failed to unmarshall agent certs response: json: cannot unmarshal string into Go value of type map[string]string")),
 			},
 		},
 		"EmptyCerts": {
@@ -100,7 +100,7 @@ func Test_GetGatewayCerts(t *testing.T) {
 					Op:  "Get",
 					URL: "https://foo.com/v1/gw/certs",
 					Err: errBoom,
-				}, "failed to request gateway certs"),
+				}, "failed to request agent certs"),
 			},
 		},
 	}
@@ -125,12 +125,12 @@ func Test_GetGatewayCerts(t *testing.T) {
 
 			httpmock.RegisterResponder(http.MethodGet, endpoint+gwCertsPath, responder)
 
-			got, gotErr := rc.GetGatewayCerts(endpointToken)
+			got, gotErr := rc.GetAgentCerts(endpointToken)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
-				t.Fatalf("GetGatewayCerts(...): -want error, +got error: %s", diff)
+				t.Fatalf("GetAgentCerts(...): -want error, +got error: %s", diff)
 			}
 			if diff := cmp.Diff(tc.want.out, got); diff != "" {
-				t.Errorf("GetGatewayCerts(...): -want result, +got result: %s", diff)
+				t.Errorf("GetAgentCerts(...): -want result, +got result: %s", diff)
 			}
 		})
 	}

--- a/internal/controllers/tlssecrets/reconciler.go
+++ b/internal/controllers/tlssecrets/reconciler.go
@@ -57,12 +57,12 @@ const (
 	keyTLSCert = "tls.crt"
 	keyTLSKey  = "tls.key"
 
-	nameUpbound          = "upbound"
-	cnAgent              = "upbound-agent"
-	cnXgql               = "xgql"
-	secretNameCA         = "uxp-ca"
-	secretNameGatewayTLS = "upbound-agent-tls"
-	secretNameXgqlTLS    = "xgql-tls"
+	nameUpbound        = "upbound"
+	cnAgent            = "upbound-agent"
+	cnXgql             = "xgql"
+	secretNameCA       = "uxp-ca"
+	secretNameAgentTLS = "upbound-agent-tls"
+	secretNameXgqlTLS  = "xgql-tls"
 )
 
 const (
@@ -87,11 +87,10 @@ var (
 		Organization: []string{nameUpbound},
 	}
 	certConfigs = map[string]*certutil.Config{
-		secretNameGatewayTLS: {
+		secretNameAgentTLS: {
 			CommonName: cnAgent,
 			AltNames: certutil.AltNames{
-				// TODO(hasan): drop "tenant-gateway" once we stop using legacy service
-				DNSNames: []string{cnAgent, "tenant-gateway"},
+				DNSNames: []string{cnAgent},
 			},
 			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
@@ -135,7 +134,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 		Named(name).
 		For(&corev1.Secret{}).
 		WithEventFilter(resource.NewPredicates(resource.AnyOf(
-			resource.IsNamed(secretNameGatewayTLS),
+			resource.IsNamed(secretNameAgentTLS),
 			resource.IsNamed(secretNameXgqlTLS),
 		))).
 		Complete(r)

--- a/internal/controllers/tlssecrets/reconciler_test.go
+++ b/internal/controllers/tlssecrets/reconciler_test.go
@@ -103,7 +103,7 @@ func TestReconcile(t *testing.T) {
 				mgr: &fake.Manager{
 					Client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errGetSecret),
@@ -120,7 +120,7 @@ func TestReconcile(t *testing.T) {
 						return nil
 					})},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 		},
 		"ErrGetCASecret": {
@@ -133,7 +133,7 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 			want: want{
 				err: errors.Wrap(errors.Wrap(errBoom, errGetCASecret), errInitCA),
@@ -151,7 +151,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 			want: want{
 				err: errors.Wrap(errors.Wrap(errBoom, errUpdateCASecret), errInitCA),
@@ -177,7 +177,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateCertSecret),
@@ -218,7 +218,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameGatewayTLS}},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: secretNameAgentTLS}},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR renames remaining `gateway`s as `agent` in the codebase. No functional change.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

By running [validation](https://github.com/upbound/universal-crossplane/blob/main/docs/developer-guide.md#validation) against UbC.
```
export LOCALDEV_CONNECT_CP_ORG=<YOUR_UBC_ORG>
export LOCALDEV_CONNECT_API_TOKEN=<YOUR_ACCESS_TOKEN>
make e2e.run
```