### PR TITLE
olm: add necessary entries to annotations for RedHat certification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Kubernetes tools
 
-OLMBUNDLE_VERSION = v0.5.1
+OLMBUNDLE_VERSION = v0.5.2
 USE_HELM3 = true
 HELM_CHART_LINT_STRICT = false
 CRDS_DIR=$(ROOT_DIR)/cluster/crds

--- a/cluster/olm/annotations.yaml.tmpl
+++ b/cluster/olm/annotations.yaml.tmpl
@@ -1,7 +1,23 @@
 annotations:
+  # OLM metadata
   operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
   operators.operatorframework.io.bundle.manifests.v1: "manifests/"
   operators.operatorframework.io.bundle.metadata.v1: "metadata/"
   operators.operatorframework.io.bundle.package.v1: "universal-crossplane"
   operators.operatorframework.io.bundle.channels.v1: "stable"
   operators.operatorframework.io.bundle.channel.default.v1: "stable"
+
+  # Operator bundle metadata
+  com.redhat.delivery.operator.bundle: true
+  com.redhat.openshift.versions: "v4.6"
+  com.redhat.delivery.backport: false
+
+  # Standard Red Hat labels
+  com.redhat.component: "universal-crossplane"
+  name: "universal-crossplane"
+  summary: "Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane."
+  io.k8s.display-name: "universal-crossplane"
+  maintainer: "Upbound Inc. <info@upbound.io>"
+  description: "Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane."
+  io.openshift.tags: "uxp,crossplane,upbound"
+  ocs.tags: "v4.6"

--- a/cluster/olm/bundle/Dockerfile
+++ b/cluster/olm/bundle/Dockerfile
@@ -1,11 +1,22 @@
 FROM scratch
 
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=universal-crossplane
+LABEL com.redhat.component="universal-crossplane"
+LABEL com.redhat.delivery.backport="false"
+LABEL com.redhat.delivery.operator.bundle="true"
+LABEL com.redhat.openshift.versions="v4.6"
+LABEL description="Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane."
+LABEL io.k8s.display-name="universal-crossplane"
+LABEL io.openshift.tags="uxp,crossplane,upbound"
+LABEL maintainer="Upbound Inc. <info@upbound.io>"
+LABEL name="universal-crossplane"
+LABEL ocs.tags="v4.6"
+LABEL operators.operatorframework.io.bundle.channel.default.v1="stable"
+LABEL operators.operatorframework.io.bundle.channels.v1="stable"
+LABEL operators.operatorframework.io.bundle.manifests.v1="manifests/"
+LABEL operators.operatorframework.io.bundle.mediatype.v1="registry+v1"
+LABEL operators.operatorframework.io.bundle.metadata.v1="metadata/"
+LABEL operators.operatorframework.io.bundle.package.v1="universal-crossplane"
+LABEL summary="Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane."
 
 COPY manifests /manifests/
 COPY metadata /metadata/

--- a/cluster/olm/bundle/metadata/annotations.yaml
+++ b/cluster/olm/bundle/metadata/annotations.yaml
@@ -1,7 +1,18 @@
 annotations:
+  com.redhat.component: universal-crossplane
+  com.redhat.delivery.backport: "false"
+  com.redhat.delivery.operator.bundle: "true"
+  com.redhat.openshift.versions: v4.6
+  description: Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane.
+  io.k8s.display-name: universal-crossplane
+  io.openshift.tags: uxp,crossplane,upbound
+  maintainer: Upbound Inc. <info@upbound.io>
+  name: universal-crossplane
+  ocs.tags: v4.6
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: universal-crossplane
+  summary: Upbound Universal Crossplane (UXP) is Upbound's official enterprise-grade distribution of Crossplane.


### PR DESCRIPTION
### Description of your changes

Add necessary entries to annotations for RedHat certification. There is a page [here](https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/reviewing-your-metadata-bundle) about required metadata but certification test doesn't pass only with them. You'll need to test it in https://connect.redhat.com by uploading the project bundle image. @grantgumina can invite you to our org there.

I'd like to say that this fixes https://github.com/upbound/universal-crossplane/issues/41 but I am not able to get enough information to verify that only the bundle image needs to be UBI-based, not all images deployed via OLM. If that assumption is not true, then you can follow the steps outlined [in this comment](https://github.com/upbound/universal-crossplane/issues/41) to produce UBI images and complete it when I'm on leave.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Passing the test in https://connect.redhat.com after building with `docker build cluster/olm/bundle -f cluster/olm/bundle/Dockerfile -t "${IMAGE_PREFIX}/universal-crossplane-olm:v1.2.2-up.1"`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
