### PR TITLE
Add "xpmetrics" route to reverse-proxy crossplane metrics

### DIFF
--- a/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  name: {{ template "name" . }}
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  type: ClusterIP

--- a/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
Reverse-proxy requests from crossplane-router to `xpmetrics` to crossplane's metrics port to make those metrics available in UbC.


I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Manually tested changes in this PR in a local-dev environment with a [modified version](https://github.com/upbound/wesaas/pull/867) of crossplane-router.