### PR TITLE
Bump Crossplane version to v1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ PACKAGE_NAME := universal-crossplane
 CROSSPLANE_REPO := https://github.com/crossplane/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.3.0
-CROSSPLANE_COMMIT := v1.3.0
+CROSSPLANE_TAG := v1.3.1
+CROSSPLANE_COMMIT := v1.3.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 AGENT_TAG := $(VERSION)


### PR DESCRIPTION
### Description of your changes

This PR bumps Crossplane version to v1.3.1.

Fixes #172 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

1. `make build local-dev`
2. Ensure crossplane running with version `v1.3.1`
