### PR TITLE
Getting started configuration should work with rc versions

### DIFF
--- a/docs/getting-started/configuration/crossplane.yaml
+++ b/docs/getting-started/configuration/crossplane.yaml
@@ -6,7 +6,7 @@ metadata:
     uxp-guide: getting-started
 spec:
   crossplane:
-    version: ">=v1.2.1"
+    version: ">=v1.2.1-0"
   dependsOn:
     - provider: registry.upbound.io/crossplane/provider-aws
       version: "v0.18.1"


### PR DESCRIPTION
### Description of your changes

Different from all our other getting started guides (e.g. [getting-started-with-aws](https://github.com/crossplane/crossplane/blob/master/docs/snippets/package/aws/crossplane.yaml#L11)) and reference platforms (e.g.[ platform-ref-gcp](https://github.com/upbound/platform-ref-gcp/blob/main/crossplane.yaml#L93)), the getting started configuration here does not work with pre-release versions (a.k.a. release candidates) of Crossplane. 

Fixes #182 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Build and install package.
