### PR TITLE
olm: remove runAsGroup and runAsUser from pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,12 @@ helm.prepare.universal-crossplane: crossplane
 
 olm.build: $(HELM) $(OLMBUNDLE)
 	@$(INFO) Generating OLM bundle
-	@$(HELM) -n upbound-system template $(HELM_CHARTS_DIR)/$(PACKAGE_NAME) --set upbound.controlPlane.permission=edit > $(WORK_DIR)/olm.yaml
+	@$(HELM) -n upbound-system template $(HELM_CHARTS_DIR)/$(PACKAGE_NAME) \
+		--set upbound.controlPlane.permission=edit \
+		--set securityContextCrossplane.runAsUser=null \
+		--set securityContextCrossplane.runAsGroup=null \
+		--set securityContextRBACManager.runAsUser=null \
+		--set securityContextRBACManager.runAsGroup=null > $(WORK_DIR)/olm.yaml
 	@$(SED_CMD) 's|RELEASE-NAME|$(PROJECT_NAME)|g' $(WORK_DIR)/olm.yaml
 	@rm -rf $(OLM_DIR)/bundle
 	@cat $(WORK_DIR)/olm.yaml | $(OLMBUNDLE) --version $(HELM_CHART_VERSION) --chart-file-path $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/Chart.yaml --extra-resources-dir $(CRDS_DIR) --output-dir $(OLM_DIR)

--- a/cluster/olm/README.md
+++ b/cluster/olm/README.md
@@ -2,11 +2,6 @@
 
 This folder contains the OLM bundle to be published in OperatorHub.
 
-> Note: We currently manually strip off the `runAsUser` and `runAsGroup` fields
-> from the Crossplane and RBAC Manager `Deployments` to work around
-> https://github.com/upbound/universal-crossplane/issues/116. This should be
-> handled automatically in the future. 
-
 Every PR that is merged and version that is tagged and promoted results in the
 publishing of the OLM bundle to
 https://releases.upbound.io/universal-crossplane. To publish a new version to


### PR DESCRIPTION
### Description of your changes

OLM does not like pods that come with their own user and group IDs. This step was manual before, so it's just about automating it.

Fixes https://github.com/upbound/universal-crossplane/issues/116

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested manually with instructions in https://github.com/upbound/universal-crossplane/tree/main/cluster/olm

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
