### PR TITLE
Add support for passing extra env vars for all components

### DIFF
--- a/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
@@ -54,6 +54,11 @@ spec:
           {{- range $arg := .Values.bootstrapper.config.args }}
             - {{ $arg }}
           {{- end }}
+          env:
+          {{- range $key, $value := .Values.bootstrapper.config.envVars }}
+            - name: {{ $key | replace "." "_" }}
+              value: {{ $value | quote }}
+          {{- end}}
           imagePullPolicy: {{ .Values.bootstrapper.image.pullPolicy }}
           resources:
             {{- toYaml .Values.bootstrapper.resources | nindent 12 }}

--- a/cluster/charts/universal-crossplane/templates/upbound-agent/_deployment-spec.tpl
+++ b/cluster/charts/universal-crossplane/templates/upbound-agent/_deployment-spec.tpl
@@ -46,6 +46,10 @@ template:
             secretKeyRef:
               name: {{ .Values.upbound.controlPlane.tokenSecretName }}
               key: token
+        {{- range $key, $value := .Values.agent.config.envVars }}
+        - name: {{ $key | replace "." "_" }}
+          value: {{ $value | quote }}
+        {{- end}}
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         ports:
         - name: agent

--- a/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
@@ -48,6 +48,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- range $key, $value := .Values.xgql.config.envVars }}
+          - name: {{ $key | replace "." "_" }}
+            value: {{ $value | quote }}
+        {{- end}}
         volumeMounts:
           - mountPath: /etc/certs/xgql
             name: certs

--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -81,8 +81,8 @@ metrics:
 # List of extra environment variables to set in the crossplane deployment.
 # EXAMPLE
 # extraEnvironmentVars:
-#   sample.key=value1
-#   ANOTHER.KEY=value2
+#   sample.key: value1
+#   ANOTHER.KEY: value2
 # RESULT
 #   - name: sample_key
 #     value: "value1"
@@ -93,8 +93,8 @@ extraEnvVarsCrossplane: {}
 # List of extra environment variables to set in the crossplane rbac manager deployment.
 # EXAMPLE
 # extraEnvironmentVars:
-#   sample.key=value1
-#   ANOTHER.KEY=value2
+#   sample.key: value1
+#   ANOTHER.KEY: value2
 # RESULT
 #   - name: sample_key
 #     value: "value1"
@@ -123,6 +123,17 @@ xgql:
   config:
     debugMode: false
     args: []
+    envVars: {}
+    # List of extra environment variables to set in the xgql deployment.
+    # EXAMPLE
+    # envVars:
+    #   sample.key: value1
+    #   ANOTHER.KEY: value2
+    # RESULT
+    #   - name: sample_key
+    #     value: "value1"
+    #   - name: ANOTHER_KEY
+    #     value: "value2"
 
 agent:
   image:
@@ -133,6 +144,17 @@ agent:
   config:
     debugMode: false
     args: []
+    envVars: {}
+    # List of extra environment variables to set in the agent deployment.
+    # EXAMPLE
+    # envVars:
+    #   sample.key: value1
+    #   ANOTHER.KEY: value2
+    # RESULT
+    #   - name: sample_key
+    #     value: "value1"
+    #   - name: ANOTHER_KEY
+    #     value: "value2"
 
 ### Bootstrapper Values
 
@@ -145,6 +167,17 @@ bootstrapper:
   config:
     debugMode: false
     args: []
+    envVars: {}
+    # List of extra environment variables to set in the bootstrapper deployment.
+    # EXAMPLE
+    # envVars:
+    #   sample.key: value1
+    #   ANOTHER.KEY: value2
+    # RESULT
+    #   - name: sample_key
+    #     value: "value1"
+    #   - name: ANOTHER_KEY
+    #     value: "value2"
 
 billing:
   awsMarketplace:


### PR DESCRIPTION
### Description of your changes

This PR adds helm parameters to set extra env vars for xgql, agent and bootstrapper by following the same conversion we used for Crossplane and Crossplane RBAC manager.

Fixes #188

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Build the chart
Helm install with default (no extra env var) - verify nothing broken/changes
Helm install with extra-envars - verify extra envvars land into the pod spec properly.
