### PR TITLE
Make upbound-agent owned by versions ConfigMap

### DIFF
--- a/cluster/charts/universal-crossplane/templates/bootstrapper/role.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/role.yaml
@@ -9,6 +9,9 @@ rules:
     resources: ["events"]
     verbs: ["create", "update", "patch", "delete"]
   - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["watch", "list"]
   - apiGroups: [""]
@@ -25,4 +28,4 @@ rules:
     {{- end}}
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "update", "watch", "list"]
+    verbs: ["create", "update", "delete", "watch", "list"]

--- a/cluster/olm/bundle/manifests/upbound-bootstrapper.role.yaml
+++ b/cluster/olm/bundle/manifests/upbound-bootstrapper.role.yaml
@@ -23,6 +23,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - watch
@@ -48,5 +56,6 @@ rules:
   verbs:
   - create
   - update
+  - delete
   - watch
   - list


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the upbound-bootstrapper to make upbound-agent owned by the
versions ConfigMap, which serves as the official indicator of installed
versions in a UXP install. This means that uninstalling UXP will now
successfully clean up the agent, as will deleting the control plane
token secret, which will cause upbound-bootstrapper to manually delete
the upbound-agent deployment.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #161 

> Issue describes have the `upbound-bootstrapper` `Deployment` itself own the `upbound-agent` `Deployment`, but while implementing the versions `ConfigMap` felt like a simpler solution that also feels like a bit more of a constant artifact that should always be present in a UXP cluster.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I have tested the following scenarios:
1. Install UXP, connect to Upbound Cloud and verify the agent comes up and connects successfully.
2. Uninstall UXP, verify agent is cleaned up successfully and control plane becomes `Unreachable`.
3. Re-install UXP, verify agent is immediately created (control plane token still exists in `upbound-system`), and control plane becomes `Ready` again.
4. Delete control plane token in `upbound-system` namespace and verify agent is immediately cleaned up and control plane transitions to `Unreachable`.