### PR TITLE
Update PostgreSQL engine version for UXP getting-started package

### DIFF
--- a/docs/getting-started/configuration/composition.yaml
+++ b/docs/getting-started/configuration/composition.yaml
@@ -136,7 +136,7 @@ spec:
             dbInstanceClass: db.t2.small
             masterUsername: masteruser
             engine: postgres
-            engineVersion: "9.6"
+            engineVersion: "12.10"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
           writeConnectionSecretToRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Updates the PostgreSQL `engineVersion` from 9.6 to 12.10 in the Composition for the getting-started configuration package.
 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #238

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

1. Created a fresh control plane (self-hosted, GKE) on Upbound Cloud.
2. Built the [xpkg](https://cloud.upbound.io/registry/ysjtang/jastang-xpkg) for the fix manually per the workaround steps outlined in #102.
3. Installed the xpkg and dependencies
```
k get pkg

NAME                                                 INSTALLED   HEALTHY   PACKAGE                                               AGE
provider.pkg.crossplane.io/crossplane-provider-aws   True        True      registry.upbound.io/crossplane/provider-aws:v0.24.1   21m

NAME                                              INSTALLED   HEALTHY   PACKAGE                                           AGE
configuration.pkg.crossplane.io/getting-started   True        True      registry.upbound.io/ysjtang/jastang-xpkg:v0.0.1   28m
```
4. Deployed the RDS instance per the [documentation](https://cloud.upbound.io/docs/getting-started/deploy-infrastructure)
5. Confirmed all infrastructure was deployed correctly and reflects the new version
```
k get aws

[...]
NAME                                                       READY   SYNCED   STATE       ENGINE     VERSION   AGE
rdsinstance.database.aws.crossplane.io/my-db-cbf2l-bp2pp   True    True     available   postgres   12.10     20m
```
6. Spot-checked on personal AWS console that the database is healthy.

