### PR TITLE
Update install.yaml to use correct FQDN

### DIFF
--- a/docs/getting-started/install.yaml
+++ b/docs/getting-started/install.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: getting-started
 spec:
-  package: registry.upbound.io/upbound/getting-started:latest
+  package: xpkg.upbound.io/upbound/getting-started:latest


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
In the [getting-started install instructions](https://cloud.upbound.io/docs/getting-started/build-control-plane/#install-via-cli), the sample `install.yaml` was still referencing `registry.upbound.io`, which needs to be updated before we build and push a new version of the xpkg from #243. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

`kubectl get pkg` after applying the updated manifest shows:

```
➜  universal-crossplane git:(fix-getting-started-install) ✗ k get pkg
NAME                                               INSTALLED   HEALTHY   PACKAGE                                           AGE
configuration.pkg.crossplane.io/getting-started    True        True      xpkg.upbound.io/upbound/getting-started:latest    29s
```
