### PR TITLE
Bump RBAC manager memory requests and limits

### DIFF
--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -74,10 +74,10 @@ webhooks:
 resourcesRBACManager:
   limits:
     cpu: 100m
-    memory: 512Mi
+    memory: 768Mi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 securityContextRBACManager:
   runAsUser: 65532


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes https://github.com/upbound/universal-crossplane/issues/264

We've seen the RBAC manager using a little under 512Mi of memory when many CRDs are installed. This can cause it to be OOM killed under the current requests and limits.


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

See https://github.com/upbound/universal-crossplane/issues/264.