### PR TITLE
Update getting started example with official provider-aws 

### DIFF
--- a/docs/getting-started/claim.yaml
+++ b/docs/getting-started/claim.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   parameters:
     storageGB: 20
+    passwordSecretName: getting-started-db-pass
   compositionSelector:
     matchLabels:
       uxp-guide: getting-started

--- a/docs/getting-started/configuration/composition.yaml
+++ b/docs/getting-started/configuration/composition.yaml
@@ -198,7 +198,9 @@ spec:
         - fromFieldPath: "spec.parameters.passwordSecretName"
           toFieldPath: "spec.forProvider.passwordSecretRef.name"
       connectionDetails:
-        - fromConnectionSecretKey: username
-        - fromConnectionSecretKey: password
-        - fromConnectionSecretKey: endpoint
-        - fromConnectionSecretKey: port
+        - name: username
+          fromFieldPath: spec.forProvider.username
+        - name: password
+          fromConnectionSecretKey: attribute.password
+        - name: endpoint
+          fromFieldPath: status.atProvider.endpoint

--- a/docs/getting-started/configuration/composition.yaml
+++ b/docs/getting-started/configuration/composition.yaml
@@ -181,6 +181,9 @@ spec:
             engineVersion: "12.10"
             skipFinalSnapshot: true
             publiclyAccessible: true
+            passwordSecretRef:
+              key: password
+              namespace: upbound-system
           writeConnectionSecretToRef:
             namespace: upbound-system
       patches:
@@ -192,6 +195,8 @@ spec:
                 fmt: "%s-postgresql"
         - fromFieldPath: "spec.parameters.storageGB"
           toFieldPath: "spec.forProvider.allocatedStorage"
+        - fromFieldPath: "spec.parameters.passwordSecretName"
+          toFieldPath: "spec.forProvider.passwordSecretRef.name"
       connectionDetails:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password

--- a/docs/getting-started/configuration/composition.yaml
+++ b/docs/getting-started/configuration/composition.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     - name: vpc
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: VPC
         spec:
           forProvider:
@@ -22,7 +22,7 @@ spec:
             enableDnsHostNames: true
     - name: subnet-a
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: Subnet
         metadata:
           labels:
@@ -36,7 +36,7 @@ spec:
             availabilityZone: us-east-1a
     - name: subnet-b
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: Subnet
         metadata:
           labels:
@@ -50,7 +50,7 @@ spec:
             availabilityZone: us-east-1b
     - name: subnet-c
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: Subnet
         metadata:
           labels:
@@ -64,8 +64,8 @@ spec:
             availabilityZone: us-east-1c
     - name: dbsubnetgroup
       base:
-        apiVersion: database.aws.crossplane.io/v1beta1
-        kind: DBSubnetGroup
+        apiVersion: rds.aws.upbound.io/v1beta1
+        kind: SubnetGroup
         spec:
           forProvider:
             region: us-east-1
@@ -74,7 +74,7 @@ spec:
               matchControllerRef: true
     - name: internetgateway
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: InternetGateway
         spec:
           forProvider:
@@ -83,49 +83,91 @@ spec:
               matchControllerRef: true
     - name: routetable
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: RouteTable
         spec:
           forProvider:
             region: us-east-1
             vpcIdSelector:
               matchControllerRef: true
-            routes:
-              - destinationCidrBlock: 0.0.0.0/0
-                gatewayIdSelector:
-                  matchControllerRef: true
-            associations:
-              - subnetIdSelector:
-                  matchLabels:
-                    zone: us-east-1a
-              - subnetIdSelector:
-                  matchLabels:
-                    zone: us-east-1b
-              - subnetIdSelector:
-                  matchLabels:
-                    zone: us-east-1c
+    - name: route
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: Route
+        spec:
+          forProvider:
+            region: us-east-1
+            destinationCidrBlock: 0.0.0.0/0
+            routeTableIdSelector:
+              matchControllerRef: true
+            gatewayIdSelector:
+              matchControllerRef: true
+    - name: routetableassociation-1a
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        spec:
+          forProvider:
+            region: us-east-1
+            routeTableIdSelector:
+              matchControllerRef: true
+            subnetIdSelector:
+               matchLabels:
+                 zone: us-east-1a
+    - name: routetableassociation-1b
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        spec:
+          forProvider:
+            region: us-east-1
+            routeTableIdSelector:
+              matchControllerRef: true
+            subnetIdSelector:
+               matchLabels:
+                 zone: us-east-1b
+    - name: routetableassociation-1c
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: RouteTableAssociation
+        spec:
+          forProvider:
+            region: us-east-1
+            routeTableIdSelector:
+              matchControllerRef: true
+            subnetIdSelector:
+               matchLabels:
+                 zone: us-east-1c
     - name: securitygroup
       base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
+        apiVersion: ec2.aws.upbound.io/v1beta1
         kind: SecurityGroup
         spec:
           forProvider:
             region: us-east-1
             vpcIdSelector:
               matchControllerRef: true
-            groupName: crossplane-getting-started
+            name: uxp-getting-started
             description: Allow access to PostgreSQL
-            ingress:
-              - fromPort: 5432
-                toPort: 5432
-                ipProtocol: tcp
-                ipRanges:
-                  - cidrIp: 0.0.0.0/0
-                    description: Everywhere
+    - name: securitygrouprule
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        spec:
+          forProvider:
+            region: us-east-1
+            type: ingress
+            fromPort: 5432
+            toPort: 5432
+            protocol: tcp
+            cidrBlocks:
+              - 0.0.0.0/0
+            securityGroupIdSelector:
+              matchControllerRef: true
     - name: rdsinstance
       base:
-        apiVersion: database.aws.crossplane.io/v1beta1
-        kind: RDSInstance
+        apiVersion: rds.aws.upbound.io/v1beta1
+        kind: Instance
         spec:
           forProvider:
             region: us-east-1
@@ -133,11 +175,11 @@ spec:
               matchControllerRef: true
             vpcSecurityGroupIDSelector:
               matchControllerRef: true
-            dbInstanceClass: db.t2.small
-            masterUsername: masteruser
+            instanceClass: db.t2.small
+            username: masteruser
             engine: postgres
             engineVersion: "12.10"
-            skipFinalSnapshotBeforeDeletion: true
+            skipFinalSnapshot: true
             publiclyAccessible: true
           writeConnectionSecretToRef:
             namespace: upbound-system

--- a/docs/getting-started/configuration/definition.yaml
+++ b/docs/getting-started/configuration/definition.yaml
@@ -33,7 +33,10 @@ spec:
                 properties:
                   storageGB:
                     type: integer
+                  passwordSecretName:
+                    type: string
                 required:
                   - storageGB
+                  - passwordSecretName
             required:
               - parameters


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Update getting  started example Composition to use https://marketplace.upbound.io/providers/upbound/provider-aws/v0.7.0 
Extend XRD with database secret name reference as we do not have password autogeneration capability in official providers yet

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
```
k apply -f claim.yaml

k get -f claim.yaml
NAME    READY   CONNECTION-SECRET   AGE
my-db   True    db-conn             117m
```

```
k get managed
NAME                                              READY   SYNCED   EXTERNAL-NAME           AGE
routetable.ec2.aws.upbound.io/my-db-vrqhc-7ltvb   True    True     rtb-0bad5a3ee46fd33d8   50m

NAME                                                   READY   SYNCED   EXTERNAL-NAME           AGE
internetgateway.ec2.aws.upbound.io/my-db-vrqhc-c6b94   True    True     igw-08e493610dbc52b09   50m

NAME                                                         READY   SYNCED   EXTERNAL-NAME                AGE
routetableassociation.ec2.aws.upbound.io/my-db-vrqhc-hb974   True    True     rtbassoc-081316b4278f2699b   50m
routetableassociation.ec2.aws.upbound.io/my-db-vrqhc-hwgtm   True    True     rtbassoc-092b059f9bef354e6   50m
routetableassociation.ec2.aws.upbound.io/my-db-vrqhc-s4pdw   True    True     rtbassoc-0c43bd012d4712341   50m

NAME                                          READY   SYNCED   EXTERNAL-NAME              AGE
subnet.ec2.aws.upbound.io/my-db-vrqhc-ffqh7   True    True     subnet-0d4fa1209ac69fc95   50m
subnet.ec2.aws.upbound.io/my-db-vrqhc-hrjc5   True    True     subnet-090c24f1e3d4ea82d   50m
subnet.ec2.aws.upbound.io/my-db-vrqhc-w9cht   True    True     subnet-00cc153c64fc37328   50m

NAME                                       READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/my-db-vrqhc-fnztr   True    True     vpc-01e398cbd1e8a9671   50m

NAME                                                     READY   SYNCED   EXTERNAL-NAME       AGE
securitygrouprule.ec2.aws.upbound.io/my-db-vrqhc-rx69l   True    True     sgrule-1368961359   50m

NAME                                         READY   SYNCED   EXTERNAL-NAME                       AGE
route.ec2.aws.upbound.io/my-db-vrqhc-f4h7q   True    True     r-rtb-0bad5a3ee46fd33d81080289494   50m

NAME                                                 READY   SYNCED   EXTERNAL-NAME          AGE
securitygroup.ec2.aws.upbound.io/my-db-vrqhc-wjtzh   True    True     sg-0caca862c4e8df31d   50m

NAME                                               READY   SYNCED   EXTERNAL-NAME       AGE
subnetgroup.rds.aws.upbound.io/my-db-vrqhc-6rjjv   True    True     my-db-vrqhc-6rjjv   50m

NAME                                            READY   SYNCED   EXTERNAL-NAME       AGE
instance.rds.aws.upbound.io/my-db-vrqhc-6s9w5   True    True     my-db-vrqhc-6s9w5   50m
```
```
k view-secret db-conn
Multiple sub keys found. Specify another argument, one of:
-> endpoint
-> password
-> username

k view-secret db-conn endpoint
my-db-vrqhc-6s9w5.czjq0bppekwt.us-east-1.rds.amazonaws.com:5432%
```