### PR TITLE
Duplicated registryCaBundleConfig in values.yaml

### DIFF
--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -66,8 +66,6 @@ packageCache:
   sizeLimit: 5Mi
   pvc: ""
 
-registryCaBundleConfig: {}
-
 webhooks:
   enabled: false
 


### PR DESCRIPTION
### Description of your changes

I was checking the chart values and noticed that there is a duplicated `registryCaBundleConfig: {}` in the values.yaml.tmp file.

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

N/A
