### PR TITLE
[release-1.9] Pin Crossplane version to v1.9.1-up.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ PACKAGE_NAME := universal-crossplane
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.9.0-up.3
-CROSSPLANE_COMMIT := v1.9.0-up.3
+CROSSPLANE_TAG := v1.9.1-up.1
+CROSSPLANE_COMMIT := v1.9.1-up.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 AGENT_TAG := $(VERSION)

--- a/cluster/charts/universal-crossplane/templates/crossplane/clusterrole.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/clusterrole.yaml
@@ -46,6 +46,7 @@ rules:
   - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/cluster/charts/universal-crossplane/templates/crossplane/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           {{- if .Values.webhooks.enabled }}
           - name: "WEBHOOK_TLS_SECRET_NAME"
             value: webhook-tls-secret

--- a/cluster/olm/bundle/manifests/crossplane_system_aggregate-to-crossplane.clusterrole.yaml
+++ b/cluster/olm/bundle/manifests/crossplane_system_aggregate-to-crossplane.clusterrole.yaml
@@ -41,6 +41,7 @@ rules:
   - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates crossplane version to v1.9.1-up.1.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref #287 #289 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Built locally.
```
make build
```

Spun up local cluster:
```
GO=go1.17.13 make local-dev
```

Created pull-secret:
```
$ up ctp pull-secret create package-pull-secret -f creds.json
upbound-system/package-pull-secret created

```

Patched ServiceAccount:
```
$ kubectl patch serviceaccount crossplane -n upbound-system -p '{"imagePullSecrets": [{"name": "package-pull-secret"}]}'
serviceaccount/crossplane patched
```

Installed private Configuration with private dependency:
```
$ kubectl crossplane install configuration xpkg.upbound.io/upbound/platform-ref-aws-staging:v0.4.1
```

Verified all installed successfully:
```
$ k get pkg
NAME                                                  INSTALLED   HEALTHY   PACKAGE                                            AGE
provider.pkg.crossplane.io/crossplane-provider-helm   True        True      xpkg.upbound.io/crossplane/provider-helm:v0.10.0   63s
provider.pkg.crossplane.io/upbound-provider-aws       True        True      xpkg.upbound.io/upbound/provider-aws:v0.14.0       71s

NAME                                                               INSTALLED   HEALTHY   PACKAGE                                                   AGE
configuration.pkg.crossplane.io/upbound-platform-ref-aws-staging   True        True      xpkg.upbound.io/upbound/platform-ref-aws-staging:v0.4.1   75s
```