### PR TITLE
Use HTTPS instead of SSH for build submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:upbound/build.git
+	url = https://github.com/upbound/build.git


### PR DESCRIPTION
Signed-off-by: Jason Tang <jason@upbound.io>


### Description of your changes

Update the url for the `build` submodule to use HTTPS instead of SSH, in line with other repositories.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Before update:
```
➜  universal-crossplane git:(main) GO=go1.17.3 make submodules
Submodule 'build' (git@github.com:upbound/build.git) registered for path 'build'
Cloning into '/Users/jasontang/workspace/universal-crossplane/build'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:upbound/build.git' into submodule path '/Users/jasontang/workspace/universal-crossplane/build' failed
Failed to clone 'build'. Retry scheduled
[...]
Failed to clone 'build' a second time, aborting
make: *** [submodules] Error 1
```

After update:
```
➜  universal-crossplane git:(main) GO=go1.17.3 make submodules
Synchronizing submodule url for 'build'
Cloning into '/Users/jasontang/workspace/universal-crossplane/build'...
Submodule path 'build': checked out '40f9d7a570f3306628b6a78fe9f33c5e156bc487'
```
