### PR TITLE
Correct case for vpcSecurityGroupIdSelector

### DIFF
--- a/docs/getting-started/configuration/composition.yaml
+++ b/docs/getting-started/configuration/composition.yaml
@@ -173,7 +173,7 @@ spec:
             region: us-east-1
             dbSubnetGroupNameSelector:
               matchControllerRef: true
-            vpcSecurityGroupIDSelector:
+            vpcSecurityGroupIdSelector:
               matchControllerRef: true
             instanceClass: db.t2.small
             username: masteruser


### PR DESCRIPTION
We noticed while playing around with the example that the spelling was incorrect, which was causing the RDS instance created to use the default security group for the VPC instead of the one specified.