### PR TITLE
Add a Makefile target for EKS Addon mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,8 +139,11 @@ git push --set-upstream upbound-origin sync-upstream-$RELEASE_BRANCH
 RELEASE_BRANCH=release-1.6
 git checkout -b $RELEASE_BRANCH upstream/$RELEASE_BRANCH
 
-# Cherry-pick upbound/crossplane specific changes - makefile, workflow and readme updates
+# Cherry-pick upbound/crossplane specific changes.
+# makefile, workflow and readme updates
 git cherry-pick -x 5d53beb3cb423b13960a92d1f8f9284c9a146ccc # https://github.com/upbound/crossplane/commit/5d53beb3cb423b13960a92d1f8f9284c9a146ccc
+# docs publishing and codeowners changes
+git cherry-pick -x 85027abd2449fa69cbd825faa3fc68f4c64bb36d # https://github.com/upbound/crossplane/commit/85027abd2449fa69cbd825faa3fc68f4c64bb36d
 
 git push upbound-upstream $RELEASE_BRANCH
 ```

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ PACKAGE_NAME := universal-crossplane
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.9.1-up.2
-CROSSPLANE_COMMIT := v1.9.1-up.2
+CROSSPLANE_TAG := v1.10.1-up.1
+CROSSPLANE_COMMIT := v1.10.1-up.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 XGQL_TAG := v0.1.5
@@ -40,7 +40,7 @@ S3_BUCKET ?= public-upbound.releases/$(PACKAGE_NAME)
 # Setup Go
 
 GO_REQUIRED_VERSION = 1.19
-GOLANGCILINT_VERSION = 1.49.0
+GOLANGCILINT_VERSION = 1.50.1
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/bootstrapper
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
@@ -51,7 +51,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Kubernetes tools
 
-UP_VERSION = v0.13.0
+UP_VERSION = v0.14.0
 UP_CHANNEL = stable
 
 OLMBUNDLE_VERSION = v0.5.2

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "bootstrapper-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsBootstrapper" . | nindent 4 }}
 spec:

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/role.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "bootstrapper-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsBootstrapper" . | nindent 4 }}
 rules:

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/rolebinding.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/rolebinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "bootstrapper-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsBootstrapper" . | nindent 4 }}
 roleRef:

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/secret-entitlement.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/secret-entitlement.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: upbound-entitlement
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsBootstrapper" . | nindent 4 }}
 type: Opaque

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/serviceaccount.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "bootstrapper-name" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if and .Values.billing.awsMarketplace.enabled .Values.billing.awsMarketplace.iamRoleARN }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.billing.awsMarketplace.iamRoleARN | quote }}

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/uxp-ca-tls-secret.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/uxp-ca-tls-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: uxp-ca
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels" . | nindent 4 }}
 type: Opaque

--- a/cluster/charts/universal-crossplane/templates/bootstrapper/versions-configmap.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/versions-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: universal-crossplane-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsBootstrapper" . | nindent 4 }}
 data:

--- a/cluster/charts/universal-crossplane/templates/crossplane/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}

--- a/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "crossplane.name" . }}-rbac-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}-rbac-manager
     release: {{ .Release.Name }}

--- a/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rbac-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}

--- a/cluster/charts/universal-crossplane/templates/crossplane/secret.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/secret.yaml
@@ -8,5 +8,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-tls-secret
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 {{- end }}

--- a/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "crossplane.name" . }}-webhooks
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}

--- a/cluster/charts/universal-crossplane/templates/crossplane/serviceaccount.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}

--- a/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "xgql-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsXgql" . | nindent 4 }}
 spec:
@@ -13,6 +14,7 @@ spec:
       labels:
         {{- include "selectorLabelsXgql" . | nindent 8 }}
     spec:
+      replicas: 1
       serviceAccountName: {{ template "xgql-name" . }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "labelsXgql" . | nindent 4 }}
 spec:
+  replicas: 1
   selector:
     matchLabels:
       {{- include "selectorLabelsXgql" . | nindent 6 }}
@@ -14,7 +15,6 @@ spec:
       labels:
         {{- include "selectorLabelsXgql" . | nindent 8 }}
     spec:
-      replicas: 1
       serviceAccountName: {{ template "xgql-name" . }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/cluster/charts/universal-crossplane/templates/xgql/service.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "xgql-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsXgql" . | nindent 4 }}
 spec:

--- a/cluster/charts/universal-crossplane/templates/xgql/serviceaccount.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "xgql-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsXgql" . | nindent 4 }}

--- a/cluster/charts/universal-crossplane/templates/xgql/tls-secret.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/tls-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: xgql-tls
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labelsXgql" . | nindent 4 }}
 type: Opaque

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -187,7 +187,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object
@@ -481,7 +481,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -192,7 +192,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object
@@ -499,7 +499,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object

--- a/cluster/olm/bundle/manifests/compositionrevisions.apiextensions.crossplane.io.customresourcedefinition.yaml
+++ b/cluster/olm/bundle/manifests/compositionrevisions.apiextensions.crossplane.io.customresourcedefinition.yaml
@@ -144,7 +144,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the given map and returns the value.
                                   type: object
                                 math:
@@ -354,7 +354,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the given map and returns the value.
                                   type: object
                                 math:

--- a/cluster/olm/bundle/manifests/compositions.apiextensions.crossplane.io.customresourcedefinition.yaml
+++ b/cluster/olm/bundle/manifests/compositions.apiextensions.crossplane.io.customresourcedefinition.yaml
@@ -148,7 +148,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the given map and returns the value.
                                   type: object
                                 math:
@@ -368,7 +368,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the given map and returns the value.
                                   type: object
                                 math:

--- a/cluster/olm/bundle/manifests/crossplane.serviceaccount.yaml
+++ b/cluster/olm/bundle/manifests/crossplane.serviceaccount.yaml
@@ -12,3 +12,4 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: crossplane
+  namespace: upbound-system

--- a/cluster/olm/bundle/manifests/rbac-manager.serviceaccount.yaml
+++ b/cluster/olm/bundle/manifests/rbac-manager.serviceaccount.yaml
@@ -12,3 +12,4 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: rbac-manager
+  namespace: upbound-system

--- a/cluster/olm/bundle/manifests/upbound-bootstrapper.role.yaml
+++ b/cluster/olm/bundle/manifests/upbound-bootstrapper.role.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: upbound-bootstrapper
+  namespace: upbound-system
 rules:
 - apiGroups:
   - ""

--- a/cluster/olm/bundle/manifests/upbound-bootstrapper.rolebinding.yaml
+++ b/cluster/olm/bundle/manifests/upbound-bootstrapper.rolebinding.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: upbound-bootstrapper
+  namespace: upbound-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/cluster/olm/bundle/manifests/upbound-bootstrapper.serviceaccount.yaml
+++ b/cluster/olm/bundle/manifests/upbound-bootstrapper.serviceaccount.yaml
@@ -10,3 +10,4 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: upbound-bootstrapper
+  namespace: upbound-system

--- a/cluster/olm/bundle/manifests/uxp-ca.secret.yaml
+++ b/cluster/olm/bundle/manifests/uxp-ca.secret.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: uxp-ca
+  namespace: upbound-system
 type: Opaque

--- a/cluster/olm/bundle/manifests/xgql-tls.secret.yaml
+++ b/cluster/olm/bundle/manifests/xgql-tls.secret.yaml
@@ -10,4 +10,5 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: xgql-tls
+  namespace: upbound-system
 type: Opaque

--- a/cluster/olm/bundle/manifests/xgql.service.yaml
+++ b/cluster/olm/bundle/manifests/xgql.service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: xgql
+  namespace: upbound-system
 spec:
   ports:
   - name: https

--- a/cluster/olm/bundle/manifests/xgql.serviceaccount.yaml
+++ b/cluster/olm/bundle/manifests/xgql.serviceaccount.yaml
@@ -10,3 +10,4 @@ metadata:
     app.kubernetes.io/version: 0.0.1
     helm.sh/chart: universal-crossplane-0.0.1
   name: xgql
+  namespace: upbound-system


### PR DESCRIPTION
### Description of your changes

This PR makes the remaining chart changes and also adds a new target to produce a Helm chart with defaults @Piotr1215 validated to be successful with AWS folks.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

The following command makes the chart in `cluster/charts/universal-crossplane` ready to be packaged and sent to ECR but it's not integrated with our CI pipeline.
```
make eksaddon.chart
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
