### PR TITLE
Make xgql replica count configuration driven

### DIFF
--- a/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labelsXgql" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.xgql.replicas }}
   selector:
     matchLabels:
       {{- include "selectorLabelsXgql" . | nindent 6 }}

--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -123,6 +123,7 @@ xgql:
     repository: upbound/xgql
     tag: %%XGQL_TAG%%
     pullPolicy: IfNotPresent
+  replicas: 1
   resources: {}
   metrics:
     enabled: false


### PR DESCRIPTION
### Description of your changes
Prior to this change, a consumer of the universal-crossplane helm chart is effectively stuck running 1 pod for the xgql deployment, unless they manually build and publish the chart with minor tweaks. This change enables consumers to override the default replica count for the xgql deployment (currently 1) by overriding the value in the values.yaml.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. make build so that the temporary values.yaml file was updated from values.yaml.tmpl.
2. Ran `helm template cluster/charts/universal-crossplane` and noted the default value was supplied successfully:
```yaml
# Source: universal-crossplane/templates/xgql/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xgql
  namespace: default
  labels:
    helm.sh/chart: universal-crossplane-0.0.1
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: xgql
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: crossplane
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: xgql
  template:
    metadata:
      labels:
        app.kubernetes.io/name: crossplane
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: xgql
    spec:
      serviceAccountName: xgql
      containers:
      - name: xgql
        image: "upbound/xgql:v0.1.5"
        imagePullPolicy: IfNotPresent
        resources:
            {}
        ports:
          - name: https
            containerPort: 8443
            protocol: TCP
        args:
          - --tls-key=/etc/certs/xgql/tls.key
          - --tls-cert=/etc/certs/xgql/tls.crt
        env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        volumeMounts:
          - mountPath: /etc/certs/xgql
            name: certs
            readOnly: true
      volumes:
        - name: certs
          secret:
            defaultMode: 420
            secretName: xgql-tls
```
3. Updated the replica value to be 2 and ran `helm template cluster/charts/universal-crossplane` and verified that spec.replicas was set to 2:
```yaml
# Source: universal-crossplane/templates/xgql/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xgql
  namespace: default
  labels:
    helm.sh/chart: universal-crossplane-0.0.1
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: xgql
spec:
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: crossplane
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: xgql
  template:
    metadata:
      labels:
        app.kubernetes.io/name: crossplane
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: xgql
    spec:
      serviceAccountName: xgql
      containers:
      - name: xgql
        image: "upbound/xgql:v0.1.5"
        imagePullPolicy: IfNotPresent
        resources:
            {}
        ports:
          - name: https
            containerPort: 8443
            protocol: TCP
        args:
          - --tls-key=/etc/certs/xgql/tls.key
          - --tls-cert=/etc/certs/xgql/tls.crt
        env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        volumeMounts:
          - mountPath: /etc/certs/xgql
            name: certs
            readOnly: true
      volumes:
        - name: certs
          secret:
            defaultMode: 420
            secretName: xgql-tls
```