### PR TITLE
Specify liveness and readiness probes for xgql deployment

### DIFF
--- a/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/xgql/deployment.yaml
@@ -36,6 +36,22 @@ spec:
           - name: metrics
             containerPort: 8080
         {{- end }}
+        {{- if .Values.xgql.health.enabled }}
+          - name: health
+            containerPort: 8088
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.xgql.health.liveness.initialDelay }}
+          periodSeconds: {{ .Values.xgql.health.liveness.period }}
+          httpGet:
+            path: /livez
+            port: health
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.xgql.health.readiness.initialDelay }}
+          periodSeconds: {{ .Values.xgql.health.readiness.period }}
+          httpGet:
+            path: /readyz
+            port: health
+        {{- end }}
         args:
           - --tls-key=/etc/certs/xgql/tls.key
           - --tls-cert=/etc/certs/xgql/tls.crt

--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -119,6 +119,14 @@ upbound:
     permission: edit
 
 xgql:
+  health:
+    enabled: false
+    liveness:
+      initialDelay: 5
+      period: 5
+    readiness:
+      initialDelay: 5
+      period: 5      
   image:
     repository: upbound/xgql
     tag: %%XGQL_TAG%%


### PR DESCRIPTION
### Description of your changes
Enable specifying liveness and readiness probes for the xgql deployment. These are off by default.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. `make helm.lint`
2. Verify we get the expected deployment by default `helm template cluster/charts/universal-crossplane`
```yaml
# Source: universal-crossplane/templates/xgql/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xgql
  namespace: default
  labels:
    helm.sh/chart: universal-crossplane-0.0.1
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: xgql
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: crossplane
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: xgql
  template:
    metadata:
      labels:
        app.kubernetes.io/name: crossplane
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: xgql
    spec:
      serviceAccountName: xgql
      containers:
      - name: xgql
        image: "thorntontn/xgql-build:2"
        imagePullPolicy: IfNotPresent
        resources:
            {}
        ports:
          - name: https
            containerPort: 8443
            protocol: TCP
        args:
          - --tls-key=/etc/certs/xgql/tls.key
          - --tls-cert=/etc/certs/xgql/tls.crt
        env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        volumeMounts:
          - mountPath: /etc/certs/xgql
            name: certs
            readOnly: true
      volumes:
        - name: certs
          secret:
            defaultMode: 420
            secretName: xgql-tls
```
3. Verify we get the expected deployment when enabling xgql.health `helm template cluster/charts/universal-crossplane --set xgql.health.enabled=true`
```yaml
# Source: universal-crossplane/templates/xgql/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xgql
  namespace: default
  labels:
    helm.sh/chart: universal-crossplane-0.0.1
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: xgql
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: crossplane
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: xgql
  template:
    metadata:
      labels:
        app.kubernetes.io/name: crossplane
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: xgql
    spec:
      serviceAccountName: xgql
      containers:
      - name: xgql
        image: "thorntontn/xgql-build:2"
        imagePullPolicy: IfNotPresent
        resources:
            {}
        ports:
          - name: https
            containerPort: 8443
            protocol: TCP
          - name: health
            containerPort: 8088
        livenessProbe:
          initialDelaySeconds: 5
          periodSeconds: 5
          httpGet:
            path: /livez
            port: health
        readinessProbe:
          initialDelaySeconds: 5
          periodSeconds: 5
          httpGet:
            path: /readyz
            port: health
        args:
          - --tls-key=/etc/certs/xgql/tls.key
          - --tls-cert=/etc/certs/xgql/tls.crt
        env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        volumeMounts:
          - mountPath: /etc/certs/xgql
            name: certs
            readOnly: true
      volumes:
        - name: certs
          secret:
            defaultMode: 420
            secretName: xgql-tls
```
4. Verify helm install still works by default
```
helm install uxp cluster/charts/universal-crossplane

kubectl describe deploy xgql
Name:                   xgql
Namespace:              default
CreationTimestamp:      Wed, 14 Dec 2022 12:01:01 -0800
Labels:                 app.kubernetes.io/component=xgql
                        app.kubernetes.io/instance=uxp
                        app.kubernetes.io/managed-by=Helm
                        app.kubernetes.io/name=crossplane
                        app.kubernetes.io/version=0.0.1
                        helm.sh/chart=universal-crossplane-0.0.1
Annotations:            deployment.kubernetes.io/revision: 1
                        meta.helm.sh/release-name: uxp
                        meta.helm.sh/release-namespace: default
Selector:               app.kubernetes.io/component=xgql,app.kubernetes.io/instance=uxp,app.kubernetes.io/name=crossplane
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app.kubernetes.io/component=xgql
                    app.kubernetes.io/instance=uxp
                    app.kubernetes.io/name=crossplane
  Service Account:  xgql
  Containers:
   xgql:
    Image:      thorntontn/xgql-build:2
    Port:       8443/TCP
    Host Port:  0/TCP
    Args:
      --tls-key=/etc/certs/xgql/tls.key
      --tls-cert=/etc/certs/xgql/tls.crt
    Environment:
      POD_NAMESPACE:   (v1:metadata.namespace)
    Mounts:
      /etc/certs/xgql from certs (ro)
  Volumes:
   certs:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  xgql-tls
    Optional:    false
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   xgql-74bf6579dd (1/1 replicas created)
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  42s   deployment-controller  Scaled up replica set xgql-74bf6579dd to 1


kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS      AGE
default              crossplane-c8489cf47-zqw5q                   1/1     Running   0             77s
default              crossplane-rbac-manager-6649857b57-xzwp9     1/1     Running   0             77s
default              upbound-bootstrapper-68449b77b9-m4rgj        1/1     Running   0             77s
default              xgql-74bf6579dd-xczhr                        1/1     Running   2 (76s ago)   77s
kube-system          coredns-565d847f94-7s9lb                     1/1     Running   0             7m2s
kube-system          coredns-565d847f94-8nkpc                     1/1     Running   0             7m2s
kube-system          etcd-kind-control-plane                      1/1     Running   0             7m17s
kube-system          kindnet-bjqg4                                1/1     Running   0             7m2s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0             7m18s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0             7m19s
kube-system          kube-proxy-hd9bm                             1/1     Running   0             7m2s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0             7m17s
local-path-storage   local-path-provisioner-684f458cdd-6djjj      1/1     Running   0             7m2s
```
5. Verify helm install still works when enabling xgql.health.enabled (note an upstream image of xgql that has liveness probes was used):
```
helm install uxp cluster/charts/universal-crossplane --set xgql.health.enabled=true

kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS      AGE
default              crossplane-c8489cf47-4j9jk                   1/1     Running   0             57s
default              crossplane-rbac-manager-6649857b57-r5xsz     1/1     Running   0             57s
default              upbound-bootstrapper-68449b77b9-nr58l        1/1     Running   0             57s
default              xgql-666db6564f-b7zzt                        1/1     Running   2 (56s ago)   57s
kube-system          coredns-565d847f94-7s9lb                     1/1     Running   0             9m24s
kube-system          coredns-565d847f94-8nkpc                     1/1     Running   0             9m24s
kube-system          etcd-kind-control-plane                      1/1     Running   0             9m39s
kube-system          kindnet-bjqg4                                1/1     Running   0             9m24s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0             9m40s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0             9m41s
kube-system          kube-proxy-hd9bm                             1/1     Running   0             9m24s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0             9m39s
local-path-storage   local-path-provisioner-684f458cdd-6djjj      1/1     Running   0             9m24s

 kubectl describe deploy xgql
Name:                   xgql
Namespace:              default
CreationTimestamp:      Wed, 14 Dec 2022 12:03:43 -0800
Labels:                 app.kubernetes.io/component=xgql
                        app.kubernetes.io/instance=uxp
                        app.kubernetes.io/managed-by=Helm
                        app.kubernetes.io/name=crossplane
                        app.kubernetes.io/version=0.0.1
                        helm.sh/chart=universal-crossplane-0.0.1
Annotations:            deployment.kubernetes.io/revision: 1
                        meta.helm.sh/release-name: uxp
                        meta.helm.sh/release-namespace: default
Selector:               app.kubernetes.io/component=xgql,app.kubernetes.io/instance=uxp,app.kubernetes.io/name=crossplane
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app.kubernetes.io/component=xgql
                    app.kubernetes.io/instance=uxp
                    app.kubernetes.io/name=crossplane
  Service Account:  xgql
  Containers:
   xgql:
    Image:       thorntontn/xgql-build:2
    Ports:       8443/TCP, 8088/TCP
    Host Ports:  0/TCP, 0/TCP
    Args:
      --tls-key=/etc/certs/xgql/tls.key
      --tls-cert=/etc/certs/xgql/tls.crt
    Liveness:   http-get http://:health/livez delay=5s timeout=1s period=5s #success=1 #failure=3
    Readiness:  http-get http://:health/readyz delay=5s timeout=1s period=5s #success=1 #failure=3
    Environment:
      POD_NAMESPACE:   (v1:metadata.namespace)
    Mounts:
      /etc/certs/xgql from certs (ro)
  Volumes:
   certs:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  xgql-tls
    Optional:    false
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   xgql-666db6564f (1/1 replicas created)
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  71s   deployment-controller  Scaled up replica set xgql-666db6564f to 1
```