### PR TITLE
don't promote image to master

### DIFF
--- a/cluster/images/uxp-bootstrapper/Makefile
+++ b/cluster/images/uxp-bootstrapper/Makefile
@@ -33,6 +33,4 @@ img.build.shared:
 		$(IMAGE_TEMP_DIR) || $(FAIL)
 
 img.promote:
-	@$(INFO) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
-	@docker buildx imagetools create -t $(TO_IMAGE) $(FROM_IMAGE)
-	@$(OK) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
+	@$(OK) Promotion disabled $(FROM_IMAGE) to $(TO_IMAGE)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
I tried re-running the `promote.artifacts` job to see if the error might just be intermittent but it failed so I assume that `make -j1 promote` won't really resolve much by not parallelizing the run and think the image promotion failure is simply because it is trying to mount a layer to promote the tag which isn't supported.  I think, as we discussed, since the charts are pinned to specific semver anyway that promotion to master is basically unnecessary so I'm just going to disable promotion for this package.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #[468](https://github.com/upbound/shimmer/issues/468)

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
