### PR TITLE
Bump XP version to v1.10.2-up.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.10.1-up.1
-CROSSPLANE_COMMIT := v1.10.1-up.1
+CROSSPLANE_TAG := v1.10.2-up.1
+CROSSPLANE_COMMIT := v1.10.2-up.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 XGQL_TAG := v0.1.5


### PR DESCRIPTION
### Description of your changes

Bump XP version to [v1.10.2-up.1](https://github.com/upbound/crossplane/releases/tag/v1.10.2-up.1).

Closes #324 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make e2e`
