### PR TITLE
chore: bump crossplane to v1.9.2-up.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ PACKAGE_NAME := universal-crossplane
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.9.1-up.2
-CROSSPLANE_COMMIT := v1.9.1-up.2
+CROSSPLANE_TAG := v1.9.2-up.1
+CROSSPLANE_COMMIT := v1.9.2-up.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 AGENT_TAG := $(VERSION)

--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -34,6 +34,9 @@ configuration:
 
 registryCaBundleConfig: {}
 
+webhooks:
+  enabled: false
+
 rbacManager:
   deploy: true
   skipAggregatedClusterRoles: true
@@ -67,9 +70,6 @@ packageCache:
   pvc: ""
 
 registryCaBundleConfig: {}
-
-webhooks:
-  enabled: false
 
 resourcesRBACManager:
   limits:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Bumping to latest 1.9 release from upbound/crossplane.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

N.A.