### PR TITLE
fix: default upbound/xfn image

### DIFF
--- a/cluster/charts/universal-crossplane/values.yaml.tmpl
+++ b/cluster/charts/universal-crossplane/values.yaml.tmpl
@@ -155,7 +155,7 @@ billing:
 xfn:
   enabled: false
   image:
-    repository: crossplane/xfn
+    repository: upbound/xfn
     tag: %%CROSSPLANE_TAG%%
     pullPolicy: IfNotPresent
   args: {}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

The default image for xfn should have been upbound/xfn instead of crossplane/xfn

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`docker pull crossplane/xfn:v1.11.2-up.1` didn't work because of the missing tag, while `docker pull upbound/xfn:v1.11.2-up.1` did work properly.