### PR TITLE
Add metrics exporter for bootstrapper

### DIFF
--- a/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
+++ b/cluster/charts/universal-crossplane/templates/bootstrapper/deployment.yaml
@@ -50,4 +50,8 @@ spec:
           imagePullPolicy: {{ .Values.bootstrapper.image.pullPolicy }}
           resources:
             {{- toYaml .Values.bootstrapper.resources | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: 8085
+              protocol: TCP
 {{- end }}

--- a/cmd/bootstrapper/main.go
+++ b/cmd/bootstrapper/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -35,6 +36,7 @@ type BootstrapCmd struct {
 	SyncPeriod  time.Duration `default:"10m"`
 	Namespace   string        `default:"upbound-system"`
 	Controllers []string      `default:"aws-marketplace" name:"controller" help:"List of controllers you want to run"`
+	MetricsPort int           `default:"8085" help:"Port for metrics server."`
 }
 
 var cli struct {
@@ -54,9 +56,10 @@ func main() {
 	cfg, err := ctrl.GetConfig()
 	ctx.FatalIfErrorf(errors.Wrap(err, "cannot get config"))
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:     s,
-		SyncPeriod: &cli.Bootstrap.SyncPeriod,
-		Namespace:  cli.Bootstrap.Namespace,
+		Scheme:             s,
+		SyncPeriod:         &cli.Bootstrap.SyncPeriod,
+		Namespace:          cli.Bootstrap.Namespace,
+		MetricsBindAddress: fmt.Sprintf(":%d", cli.Bootstrap.MetricsPort),
 	})
 	ctx.FatalIfErrorf(errors.Wrap(err, "cannot create manager"))
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR adds a command-line flag to boostrapper for setting its metrics port, and configures its controller-manager to host a metrics exporter at that port.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Apply the following values overrides:

```patch
diff --git a/cluster/local/config/universal-crossplane/value-overrides.yaml.tmpl b/cluster/local/config/universal-crossplane/value-overrides.yaml.tmpl
index e69de29..bf5b8a2 100644
--- a/cluster/local/config/universal-crossplane/value-overrides.yaml.tmpl
+++ b/cluster/local/config/universal-crossplane/value-overrides.yaml.tmpl
@@ -0,0 +1,10 @@
+billing:
+  awsMarketplace:
+    enabled: true
+
+bootstrapper:
+  config:
+    envVars:
+      AWS_ACCESS_KEY_ID: <REDACTED>
+      AWS_SECRET_ACCESS_KEY: <REDACTED>
+      AWS_DEFAULT_REGION: us-west-2
```

Run `make build local-dev`. Then port-forward to the bootstrapper's metrics port, and curl it:

```
branden@crateria managed-control-planes % k -n upbound-system port-forward pod/upbound-bootstrapper-76898f57c7-bc42w 8085:8085 2>&1 >/dev/null &
[1] 15261
branden@crateria managed-control-planes % curl -s localhost:8085/metrics | head
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
# TYPE certwatcher_read_certificate_total counter
certwatcher_read_certificate_total 0
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="aws-marketplace"} 0
# HELP controller_runtime_max_concurrent_reconciles Maximum number of concurrent reconciles per controller
branden@crateria managed-control-planes % 
```