### PR TITLE
Bump upbound crossplane to v1.12.1-up.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.12.1-up.1
-CROSSPLANE_COMMIT := v1.12.1-up.1
+CROSSPLANE_TAG := v1.12.1-up.2
+CROSSPLANE_COMMIT := v1.12.1-up.2
 
 BOOTSTRAPPER_TAG := $(VERSION)
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -43,7 +43,7 @@ planes.
 | hostNetwork | bool | `false` | Enable hostNetwork for Crossplane. Caution: setting it to true means Crossplane's Pod will have high privileges. |
 | image.pullPolicy | string | `"IfNotPresent"` | Crossplane image pull policy used in all containers. |
 | image.repository | string | `"upbound/crossplane"` | Crossplane image. |
-| image.tag | string | `"v1.12.1-up.1"` | Crossplane image tag: if not set, appVersion field from Chart.yaml is used. |
+| image.tag | string | `"v1.12.1-up.2"` | Crossplane image tag: if not set, appVersion field from Chart.yaml is used. |
 | imagePullSecrets | object | `{}` | Names of image pull secrets to use. |
 | leaderElection | bool | `true` | Enable leader election for Crossplane Managers pod. |
 | metrics.enabled | bool | `false` | Expose Crossplane and RBAC Manager metrics endpoint. |
@@ -92,7 +92,7 @@ planes.
 | xfn.cache | object | `{"configMap":"","medium":"","pvc":"","sizeLimit":"1Gi"}` | Cache configuration for xfn. |
 | xfn.enabled | bool | `false` | Enable alpha xfn sidecar container that runs Composition Functions. Note you also need to run Crossplane with --enable-composition-functions for it to call xfn. |
 | xfn.extraEnvVars | object | `{}` | List of additional environment variables for the xfn container. |
-| xfn.image | object | `{"pullPolicy":"IfNotPresent","repository":"upbound/xfn","tag":"v1.12.1-up.1"}` | Image for xfn: if tag is not set appVersion field from Chart.yaml is used. |
+| xfn.image | object | `{"pullPolicy":"IfNotPresent","repository":"upbound/xfn","tag":"v1.12.1-up.2"}` | Image for xfn: if tag is not set appVersion field from Chart.yaml is used. |
 | xfn.resources | object | `{"limits":{"cpu":"2000m","memory":"2Gi"},"requests":{"cpu":"1000m","memory":"1Gi"}}` | Resources definition for xfn. |
 | xfn.resources.limits.cpu | string | `"2000m"` | CPU resource limits for RBAC Manager. |
 | xfn.resources.limits.memory | string | `"2Gi"` | Memory resource limits for RBAC Manager. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- Crossplane image.
   repository: upbound/crossplane
   # -- Crossplane image tag: if not set, appVersion field from Chart.yaml is used.
-  tag: "v1.12.1-up.1"
+  tag: "v1.12.1-up.2"
   # -- Crossplane image pull policy used in all containers.
   pullPolicy: IfNotPresent
 
@@ -168,7 +168,7 @@ xfn:
   # -- Image for xfn: if tag is not set appVersion field from Chart.yaml is used.
   image:
     repository: upbound/xfn
-    tag: "v1.12.1-up.1"
+    tag: "v1.12.1-up.2"
     pullPolicy: IfNotPresent
   # -- List of additional args for the xfn container.
   args: []


### PR DESCRIPTION
### Description of your changes

Consume [v1.12.1-up.2](https://github.com/upbound/crossplane/releases/tag/v1.12.1-up.2) of upbound/crossplane.

As part of https://github.com/upbound/universal-crossplane/issues/369

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
make e2e
```
