### PR TITLE
Add sanity checks before promotion to the release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -33,6 +33,15 @@ according to the declared schedule, you should have:
 - [ ] Cut [UXP][uxp] `vX.Y.Z-up.K` release from the `release-X.Y` branch by:
   - [ ] Running the [Tag workflow][tag-uxp] on the `release-vX.Y` branch with the proper release version, `vX.Y.Z-up.K`. Use `Release vX.Y.Z-up.K` as message (FYI: the format suggested is only for consistency, there is no actual dependency on it).
   - [ ] Running the [CI workflow][ci-uxp] on the `release-vX.Y` branch to build and publish the latest tagged artifacts.
+  - [ ] Verify that the tagged build version exists on the [releases.upbound.io](https://releases.upbound.io/universal-crossplane/) `build` channel, e.g. `build/release-X.Y/vX.Y.Z-up.K/...`
+- [ ] Verify the produced helm chart available in the `build` channnel at `build/release-X.Y/vX.Y.Z-up.K/charts` by doing some sanity checks:
+  - [ ] Installs on a cluster properly with `helm -n upbound-system install universal-crossplane <path-to-chart.tgz> --create-namespace`.
+  - [ ] Uses the correct image versions of `upbound/crossplane`, e.g. `kubectl -n upbound-system get pods  -o yaml | grep image:`
+  - [ ] Installation of the following reference platforms works:
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-aws
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-azure
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-gcp
+    - [ ] Verify at least one of the above reference platforms works end to end by configuring and creating a claim, e.g. using https://github.com/upbound/platform-ref-gcp/blob/main/examples/cluster-claim.yaml
 - [ ] Run the [Promote workflow][promote-uxp] on the `release-vX.Y` branch to promote `vX.Y.Z-up.K` to [stable][uxp-stable-channel], it should contain `universal-crossplane-X.Y.Z-up.K.tgz`. Verify everything is correctly working by running `up uxp install` against an empty Kubernetes cluster, e.g. `kind create cluster`, which should result in an healthy UXP installation with expected image versions.
 - [ ] Created and published well authored release notes for [UXP][uxp-releases] `vX.Y.Z-up.K`. See the previous release for an example, these should at least:
   - [ ] enumerate relevant updates that were merged in [u/xp][upbound-xp-fork] and [u/uxp][uxp].

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -34,8 +34,17 @@ according to the declared [schedule][uxp-schedule], you should have:
 - [ ] Cut [UXP][uxp] `vX.Y.0-up.1` release from the `release-X.Y` branch by:
   - [ ] Running the [Tag workflow][tag-uxp] on the `release-vX.Y` branch with the proper release version, `vX.Y.0-up.1`. Message suggested but not required: `Release vX.Y.0-up.1`.
   - [ ] Running the [CI workflow][ci-uxp] on the `release-vX.Y` branch to build and publish the latest tagged artifacts.
+  - [ ] Verify that the tagged build version exists on the [releases.upbound.io](https://releases.upbound.io/universal-crossplane/) `build` channel, e.g. `build/release-X.Y/vX.Y.Z-up.K/...`
 - [ ] Cut the next prerelease of [UXP][uxp] from the `main` branch, `vX.<Y+1>.0-up.1-rc.1` by:
   - [ ] Running the [Tag workflow][tag-uxp] on the `main` branch with the proper release version, `vX.<Y+1>.0-up.1-rc.1`. Message suggested but not required: `Release vX.<Y+1>.0-up.1-rc.1`.
+- [ ] Verify the produced helm chart available in the `build` channnel at `build/release-X.Y/vX.Y.Z-up.K/charts` by doing some sanity checks:
+  - [ ] Installs on a cluster properly with `helm -n upbound-system install universal-crossplane <path-to-chart.tgz> --create-namespace`.
+  - [ ] Uses the correct image versions of `upbound/crossplane`, e.g. `kubectl -n upbound-system get pods  -o yaml | grep image:`
+  - [ ] Installation of the following reference platforms works:
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-aws
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-azure
+    - [ ] https://marketplace.upbound.io/configurations/upbound/platform-ref-gcp
+    - [ ] Verify at least one of the above reference platforms works end to end by configuring and creating a claim, e.g. using https://github.com/upbound/platform-ref-gcp/blob/main/examples/cluster-claim.yaml
 - [ ] Run the [Promote workflow][promote-uxp] to promote `vX.Y.0-up.1` to [stable][uxp-stable-channel], it should contain `universal-crossplane-X.Y.0-up.1.tgz`. Verify everything is correctly working by running `up uxp install` against an empty Kubernetes cluster, e.g. `kind create cluster`, which should result in an healthy UXP installation with expected image versions.
 - [ ] Created and published well authored release notes for [UXP][uxp-releases] `vX.Y.0-up.1`. See the previous release for an example, these should at least:
   - [ ] enumerate relevant updates that were merged in [u/xp][upbound-xp-fork] and [u/uxp][uxp].


### PR DESCRIPTION
### Description of your changes

This PR adds steps to the release process to verify the UXP package before promotion.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I followed the steps during https://github.com/upbound/universal-crossplane/issues/369