### PR TITLE
increased default cpu and memory for crossplane and rbac pods to impr…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ crossplane:
 	@$(SED_CMD) 's|repository: crossplane/crossplane|repository: upbound/crossplane|g' '$(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml'
 	@$(SED_CMD) 's|repository: crossplane/xfn|repository: upbound/xfn|g' '$(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml'
 	@$(SED_CMD) 's|tag: ""|tag: "$(CROSSPLANE_TAG)"|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|cpu: 100m|cpu: 3000m|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|memory: 512Mi|memory: 3Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|memory: 256Mi|memory: 2Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@cat $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/uxp-values.yaml >> $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@$(OK) Crossplane chart has been fetched
 

--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,9 @@ crossplane:
 	@$(SED_CMD) 's|repository: crossplane/crossplane|repository: upbound/crossplane|g' '$(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml'
 	@$(SED_CMD) 's|repository: crossplane/xfn|repository: upbound/xfn|g' '$(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml'
 	@$(SED_CMD) 's|tag: ""|tag: "$(CROSSPLANE_TAG)"|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
-	@$(SED_CMD) 's|cpu: 100m|cpu: 3000m|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
-	@$(SED_CMD) 's|memory: 512Mi|memory: 3Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
-	@$(SED_CMD) 's|memory: 256Mi|memory: 2Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|cpu: 100m|cpu: 1000m|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|memory: 512Mi|memory: 2Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
+	@$(SED_CMD) 's|memory: 256Mi|memory: 1Gi|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@cat $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/uxp-values.yaml >> $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@$(OK) Crossplane chart has been fetched
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -69,14 +69,14 @@ planes.
 | registryCaBundleConfig.key | string | `""` | The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. |
 | registryCaBundleConfig.name | string | `""` | The ConfigMap name containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. |
 | replicas | int | `1` | The number of Crossplane pod `replicas` to deploy. |
-| resourcesCrossplane.limits.cpu | string | `"100m"` | CPU resource limits for the Crossplane pod. |
-| resourcesCrossplane.limits.memory | string | `"512Mi"` | Memory resource limits for the Crossplane pod. |
-| resourcesCrossplane.requests.cpu | string | `"100m"` | CPU resource requests for the Crossplane pod. |
-| resourcesCrossplane.requests.memory | string | `"256Mi"` | Memory resource requests for the Crossplane pod. |
-| resourcesRBACManager.limits.cpu | string | `"100m"` | CPU resource limits for the RBAC Manager pod. |
-| resourcesRBACManager.limits.memory | string | `"512Mi"` | Memory resource limits for the RBAC Manager pod. |
-| resourcesRBACManager.requests.cpu | string | `"100m"` | CPU resource requests for the RBAC Manager pod. |
-| resourcesRBACManager.requests.memory | string | `"256Mi"` | Memory resource requests for the RBAC Manager pod. |
+| resourcesCrossplane.limits.cpu | string | `"3000m"` | CPU resource limits for the Crossplane pod. |
+| resourcesCrossplane.limits.memory | string | `"3Gi"` | Memory resource limits for the Crossplane pod. |
+| resourcesCrossplane.requests.cpu | string | `"3000m"` | CPU resource requests for the Crossplane pod. |
+| resourcesCrossplane.requests.memory | string | `"2Gi"` | Memory resource requests for the Crossplane pod. |
+| resourcesRBACManager.limits.cpu | string | `"3000m"` | CPU resource limits for the RBAC Manager pod. |
+| resourcesRBACManager.limits.memory | string | `"3Gi"` | Memory resource limits for the RBAC Manager pod. |
+| resourcesRBACManager.requests.cpu | string | `"3000m"` | CPU resource requests for the RBAC Manager pod. |
+| resourcesRBACManager.requests.memory | string | `"2Gi"` | Memory resource requests for the RBAC Manager pod. |
 | securityContextCrossplane.allowPrivilegeEscalation | bool | `false` | Enable `allowPrivilegeEscalation` for the Crossplane pod. |
 | securityContextCrossplane.readOnlyRootFilesystem | bool | `true` | Set the Crossplane pod root file system as read-only. |
 | securityContextCrossplane.runAsGroup | int | `65532` | The group ID used by the Crossplane pod. |

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -69,14 +69,14 @@ planes.
 | registryCaBundleConfig.key | string | `""` | The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. |
 | registryCaBundleConfig.name | string | `""` | The ConfigMap name containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. |
 | replicas | int | `1` | The number of Crossplane pod `replicas` to deploy. |
-| resourcesCrossplane.limits.cpu | string | `"3000m"` | CPU resource limits for the Crossplane pod. |
-| resourcesCrossplane.limits.memory | string | `"3Gi"` | Memory resource limits for the Crossplane pod. |
-| resourcesCrossplane.requests.cpu | string | `"3000m"` | CPU resource requests for the Crossplane pod. |
-| resourcesCrossplane.requests.memory | string | `"2Gi"` | Memory resource requests for the Crossplane pod. |
-| resourcesRBACManager.limits.cpu | string | `"3000m"` | CPU resource limits for the RBAC Manager pod. |
-| resourcesRBACManager.limits.memory | string | `"3Gi"` | Memory resource limits for the RBAC Manager pod. |
-| resourcesRBACManager.requests.cpu | string | `"3000m"` | CPU resource requests for the RBAC Manager pod. |
-| resourcesRBACManager.requests.memory | string | `"2Gi"` | Memory resource requests for the RBAC Manager pod. |
+| resourcesCrossplane.limits.cpu | string | `"1000m"` | CPU resource limits for the Crossplane pod. |
+| resourcesCrossplane.limits.memory | string | `"2Gi"` | Memory resource limits for the Crossplane pod. |
+| resourcesCrossplane.requests.cpu | string | `"1000m"` | CPU resource requests for the Crossplane pod. |
+| resourcesCrossplane.requests.memory | string | `"1Gi"` | Memory resource requests for the Crossplane pod. |
+| resourcesRBACManager.limits.cpu | string | `"1000m"` | CPU resource limits for the RBAC Manager pod. |
+| resourcesRBACManager.limits.memory | string | `"2Gi"` | Memory resource limits for the RBAC Manager pod. |
+| resourcesRBACManager.requests.cpu | string | `"1000m"` | CPU resource requests for the RBAC Manager pod. |
+| resourcesRBACManager.requests.memory | string | `"1Gi"` | Memory resource requests for the RBAC Manager pod. |
 | securityContextCrossplane.allowPrivilegeEscalation | bool | `false` | Enable `allowPrivilegeEscalation` for the Crossplane pod. |
 | securityContextCrossplane.readOnlyRootFilesystem | bool | `true` | Set the Crossplane pod root file system as read-only. |
 | securityContextCrossplane.runAsGroup | int | `65532` | The group ID used by the Crossplane pod. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -90,14 +90,14 @@ priorityClassName: ""
 resourcesCrossplane:
   limits:
     # -- CPU resource limits for the Crossplane pod.
-    cpu: 100m
+    cpu: 3000m
     # -- Memory resource limits for the Crossplane pod.
-    memory: 512Mi
+    memory: 3072Mi
   requests:
     # -- CPU resource requests for the Crossplane pod.
-    cpu: 100m
+    cpu: 2000m
     # -- Memory resource requests for the Crossplane pod.
-    memory: 256Mi
+    memory: 2048Mi
 
 securityContextCrossplane:
   # -- The user ID used by the Crossplane pod.
@@ -122,14 +122,14 @@ packageCache:
 resourcesRBACManager:
   limits:
     # -- CPU resource limits for the RBAC Manager pod.
-    cpu: 100m
+    cpu: 300m
     # -- Memory resource limits for the RBAC Manager pod.
-    memory: 512Mi
+    memory: 768Mi
   requests:
     # -- CPU resource requests for the RBAC Manager pod.
-    cpu: 100m
+    cpu: 200m
     # -- Memory resource requests for the RBAC Manager pod.
-    memory: 256Mi
+    memory: 512Mi
 
 securityContextRBACManager:
   # -- The user ID used by the RBAC Manager pod.

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -92,12 +92,12 @@ resourcesCrossplane:
     # -- CPU resource limits for the Crossplane pod.
     cpu: 3000m
     # -- Memory resource limits for the Crossplane pod.
-    memory: 3072Mi
+    memory: 3Gi
   requests:
     # -- CPU resource requests for the Crossplane pod.
-    cpu: 2000m
+    cpu: 3000m
     # -- Memory resource requests for the Crossplane pod.
-    memory: 2048Mi
+    memory: 2Gi
 
 securityContextCrossplane:
   # -- The user ID used by the Crossplane pod.
@@ -122,14 +122,14 @@ packageCache:
 resourcesRBACManager:
   limits:
     # -- CPU resource limits for the RBAC Manager pod.
-    cpu: 300m
+    cpu: 3000m
     # -- Memory resource limits for the RBAC Manager pod.
-    memory: 768Mi
+    memory: 3Gi
   requests:
     # -- CPU resource requests for the RBAC Manager pod.
-    cpu: 200m
+    cpu: 3000m
     # -- Memory resource requests for the RBAC Manager pod.
-    memory: 512Mi
+    memory: 2Gi
 
 securityContextRBACManager:
   # -- The user ID used by the RBAC Manager pod.

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -90,14 +90,14 @@ priorityClassName: ""
 resourcesCrossplane:
   limits:
     # -- CPU resource limits for the Crossplane pod.
-    cpu: 3000m
+    cpu: 1000m
     # -- Memory resource limits for the Crossplane pod.
-    memory: 3Gi
+    memory: 2Gi
   requests:
     # -- CPU resource requests for the Crossplane pod.
-    cpu: 3000m
+    cpu: 1000m
     # -- Memory resource requests for the Crossplane pod.
-    memory: 2Gi
+    memory: 1Gi
 
 securityContextCrossplane:
   # -- The user ID used by the Crossplane pod.
@@ -122,14 +122,14 @@ packageCache:
 resourcesRBACManager:
   limits:
     # -- CPU resource limits for the RBAC Manager pod.
-    cpu: 3000m
+    cpu: 1000m
     # -- Memory resource limits for the RBAC Manager pod.
-    memory: 3Gi
+    memory: 2Gi
   requests:
     # -- CPU resource requests for the RBAC Manager pod.
-    cpu: 3000m
+    cpu: 1000m
     # -- Memory resource requests for the RBAC Manager pod.
-    memory: 2Gi
+    memory: 1Gi
 
 securityContextRBACManager:
   # -- The user ID used by the RBAC Manager pod.


### PR DESCRIPTION
…ove developer experience

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Increased cpu and memory allocation for Crossplane and RBAC pods because the current defaults cause issues for customers including unresponsiveness, throttling and community to official provider migration pain. Some users with low Kubernetes management cluster resources including for local development container runtime resources may need to manually reduce the Crossplane and RBAC resource settings using e.g. the following, but for the majority of users the new settings should provide a much better experience.

up uxp install \
  --set "resourcesCrossplane.limits.cpu=100m" \
  --set "resourcesCrossplane.limits.memory=512Mi" \
  --set "resourcesCrossplane.requests.cpu=100m" \
  --set "resourcesCrossplane.requests.memory=256Mi"

Please merge this branch if it all looks good.

Thanks.


Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
The config has been run successfully to reduce cpu and memory related issues.