### PR TITLE
Bump Upbound Crossplane to v1.13.2-up.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.13.2-up.2
-CROSSPLANE_COMMIT := v1.13.2-up.2
+CROSSPLANE_TAG := v1.13.2-up.3
+CROSSPLANE_COMMIT := v1.13.2-up.3
 
 BOOTSTRAPPER_TAG := $(VERSION)
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -43,7 +43,7 @@ planes.
 | hostNetwork | bool | `false` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork`` grants the Crossplane Pod access to the host network namespace. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy used for Crossplane and RBAC Manager pods. |
 | image.repository | string | `"upbound/crossplane"` | Repository for the Crossplane pod image. |
-| image.tag | string | `"v1.13.2-up.2"` | The Crossplane image tag. Defaults to the value of `appVersion` in Chart.yaml. |
+| image.tag | string | `"v1.13.2-up.3"` | The Crossplane image tag. Defaults to the value of `appVersion` in Chart.yaml. |
 | imagePullSecrets | object | `{}` | The imagePullSecret names to add to the Crossplane ServiceAccount. |
 | leaderElection | bool | `true` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. |
 | metrics.enabled | bool | `false` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. |
@@ -97,7 +97,7 @@ planes.
 | xfn.extraEnvVars | object | `{}` | Add custom environmental variables to the Composite function runner container. Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`. |
 | xfn.image.pullPolicy | string | `"IfNotPresent"` | Composite function runner container image pull policy. |
 | xfn.image.repository | string | `"upbound/xfn"` | Composite function runner container image. |
-| xfn.image.tag | string | `"v1.13.2-up.2"` | Composite function runner container image tag. Defaults to the value of `appVersion` in Chart.yaml. |
+| xfn.image.tag | string | `"v1.13.2-up.3"` | Composite function runner container image tag. Defaults to the value of `appVersion` in Chart.yaml. |
 | xfn.resources.limits.cpu | string | `"2000m"` | CPU resource limits for the Composite function runner container. |
 | xfn.resources.limits.memory | string | `"2Gi"` | Memory resource limits for the Composite function runner container. |
 | xfn.resources.requests.cpu | string | `"1000m"` | CPU resource requests for the Composite function runner container. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Repository for the Crossplane pod image.
   repository: upbound/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in Chart.yaml.
-  tag: "v1.13.2-up.2"
+  tag: "v1.13.2-up.3"
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
 
@@ -173,7 +173,7 @@ xfn:
     # -- Composite function runner container image.
     repository: upbound/xfn
     # -- Composite function runner container image tag. Defaults to the value of `appVersion` in Chart.yaml.
-    tag: "v1.13.2-up.2"
+    tag: "v1.13.2-up.3"
     # -- Composite function runner container image pull policy.
     pullPolicy: IfNotPresent
   # -- Add custom arguments to the Composite functions runner container.

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -283,7 +283,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -772,7 +772,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1192,7 +1192,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1776,7 +1776,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -2265,7 +2265,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -2685,7 +2685,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -280,7 +280,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -772,7 +772,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1196,7 +1196,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType

--- a/cluster/olm/bundle/manifests/compositionrevisions.apiextensions.crossplane.io.customresourcedefinition.yaml
+++ b/cluster/olm/bundle/manifests/compositionrevisions.apiextensions.crossplane.io.customresourcedefinition.yaml
@@ -219,7 +219,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -577,7 +577,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -871,7 +871,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1319,7 +1319,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -1677,7 +1677,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1971,7 +1971,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType

--- a/cluster/olm/bundle/manifests/compositions.apiextensions.crossplane.io.customresourcedefinition.yaml
+++ b/cluster/olm/bundle/manifests/compositions.apiextensions.crossplane.io.customresourcedefinition.yaml
@@ -216,7 +216,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -574,7 +574,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -868,7 +868,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType


### PR DESCRIPTION
### Description of your changes

Bumps Upbound Crossplane to [v1.13.2-up.3](https://github.com/upbound/crossplane/releases/tag/v1.13.2-up.3)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```bash
up uxp install --set image.tag=v1.13.2-up.3

cat <<EOF | kubectl apply -f -
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: xnopresources.nop.example.org
spec:
  compositeTypeRef:
    apiVersion: nop.example.org/v1alpha1
    kind: XNopResource
  resources:
  - name: nop-resource-1
    base:
     apiVersion: nop.crossplane.io/v1alpha1
     kind: NopResource
     spec:
      forProvider:
        conditionAfter:
        - conditionType: Ready
          conditionStatus: "False"
          time: 0s
        - conditionType: Ready
          conditionStatus: "True"
          time: 1s
    patches:
    - type: FromCompositeFieldPath
      fromFieldPath: spec.coolField
      toFieldPath: metadata.annotations[cool-field]
      transforms:
      - type: convert
        convert:
          toType: array
          format: json
EOF

# The above succeeds instead of failing with the errors in the PR description here: https://github.com/crossplane/crossplane/pull/4825
```

