### PR TITLE
Fix multi-platform builds for arm64

### DIFF
--- a/cluster/images/uxp-bootstrapper/Dockerfile
+++ b/cluster/images/uxp-bootstrapper/Dockerfile
@@ -1,6 +1,9 @@
-FROM BASEIMAGE
+FROM gcr.io/distroless/static@sha256:d2b0ec3141031720cf5eedef3493b8e129bc91935a43b50562fbe5429878d96b
 
-ADD bootstrapper /usr/local/bin/
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY bin/$TARGETOS\_$TARGETARCH/bootstrapper /usr/local/bin/
 EXPOSE 8080
 USER 65532
 ENTRYPOINT ["bootstrapper"]

--- a/cluster/images/uxp-bootstrapper/Makefile
+++ b/cluster/images/uxp-bootstrapper/Makefile
@@ -1,13 +1,11 @@
 # ====================================================================================
 # Setup Project
 
-PLATFORMS := linux_amd64 linux_arm64
 include ../../../build/makelib/common.mk
 
 # ====================================================================================
 #  Options
-IMAGE = $(BUILD_REGISTRY)/uxp-bootstrapper-$(ARCH)
-OSBASEIMAGE = gcr.io/distroless/static@sha256:d2b0ec3141031720cf5eedef3493b8e129bc91935a43b50562fbe5429878d96b
+
 include ../../../build/makelib/imagelight.mk
 
 # ====================================================================================
@@ -25,8 +23,7 @@ img.publish:
 
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/bootstrapper $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
+	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
 	@docker buildx build $(BUILD_ARGS) \
 		--platform $(IMAGE_PLATFORMS) \
 		-t $(IMAGE) \


### PR DESCRIPTION
Currently we're somehow building a multi-platform image (i.e. manifest list) but the arm64 image has an amd64 bootstrapper binary in it. I'm honestly not exactly sure how this is happening.

In an attempt to fix it, I've copied the Makefile and Dockerfile from Crossplane v1.16 (before it moved to Earthly for image builds). I've verified that the arm64 image works locally - I think we need to actually build and push an image in CI to test multiplatform.

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
