### PR TITLE
Mirror Upbound/Crossplane to Spaces artifacts registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,3 +261,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           AWS_DEFAULT_REGION: us-east-1
+
+  mirror-spaces-artifacts:
+    runs-on: ubuntu-20.04
+    needs: publish-artifacts
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
+
+    steps:
+      - name: Set Crossplane Version
+        run: make crossplane.version > $GITHUB_ENV
+
+      - name: Setup Crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Login to Spaces Artifacts Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        if: env.XPKG_SPACES_ARTIFACTS_ACCESS_ID != ''
+        with:
+          registry: xpkg.upbound.io/spaces-artifacts
+          username: ${{ secrets.XPKG_SPACES_ARTIFACTS_ACCESS_ID }}
+          password: ${{ secrets.XPKG_SPACES_ARTIFACTS_TOKEN }}
+
+      - name: Copy Upbound Crossplane image to Spaces Artifacts Registry
+        if: env.XPKG_SPACES_ARTIFACTS_ACCESS_ID != ''
+        run: crane cp xpkg.upbound.io/upbound/crossplane:${CROSSPLANE_VERSION} xpkg.upbound.io/spaces-artifacts/crossplane:${CROSSPLANE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ crossplane:
 	@cat $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/uxp-values.yaml >> $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@$(OK) Crossplane chart has been fetched
 
+crossplane.version:
+	@echo CROSSPLANE_VERSION=$(CROSSPLANE_TAG)
+
 eksaddon.chart: crossplane
 	@$(INFO) Generating values.yaml for the EKS Add-on chart
 	@$(SED_CMD) 's|repository: upbound/crossplane|repository: $(EKS_ADDON_REGISTRY)/upbound/crossplane|g' $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml


### PR DESCRIPTION
### Description of your changes

Mirrors Upbound/Crossplane images to Spaces Artifacts Registry from main and release branches.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI
