### PR TITLE
Mirror spaces artifacts: Checkout repo first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,14 @@ jobs:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
       - name: Set Crossplane Version
         run: make crossplane.version > $GITHUB_ENV
 


### PR DESCRIPTION
### Description of your changes

Follow up for: https://github.com/upbound/universal-crossplane/pull/472

Otherwise it fails with since Makefile is not around:

<img width="570" alt="Screenshot 2024-09-16 at 13 42 12" src="https://github.com/user-attachments/assets/0205d93d-0afd-455b-9c7e-c812481d395a">


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI
