### PR TITLE
Mirror spaces artifacts: Pass XPKG_SPACES_ARTIFACTS_ACCESS_ID as env to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
+  XPKG_SPACES_ARTIFACTS_ACCESS_ID: ${{ secrets.XPKG_SPACES_ARTIFACTS_ACCESS_ID }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:


### PR DESCRIPTION
### Description of your changes

Another follow up after https://github.com/upbound/universal-crossplane/pull/472

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

You never know without testing and this is only tested in CI after merged into main 😕 