### PR TITLE
[release-1.15] Bump Crossplane 1.15.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.15.3-up.1
-CROSSPLANE_COMMIT := v1.15.3-up.1
+CROSSPLANE_TAG := v1.15.5-up.1
+CROSSPLANE_COMMIT := v1.15.5-up.1
 
 BOOTSTRAPPER_TAG := $(VERSION)
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -45,7 +45,7 @@ planes.
 | hostNetwork | bool | `false` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy used for Crossplane and RBAC Manager pods. |
 | image.repository | string | `"xpkg.upbound.io/upbound/crossplane"` | Repository for the Crossplane pod image. |
-| image.tag | string | `"v1.15.3-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
+| image.tag | string | `"v1.15.5-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
 | imagePullSecrets | object | `{}` | The imagePullSecret names to add to the Crossplane ServiceAccount. |
 | leaderElection | bool | `true` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. |
 | metrics.enabled | bool | `false` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. |

--- a/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/universal-crossplane/templates/crossplane/rbac-manager-managed-clusterroles.yaml
@@ -103,6 +103,10 @@ rules:
   - pkg.crossplane.io
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
   resources: [customresourcedefinitions]
@@ -139,6 +143,10 @@ rules:
   - pkg.crossplane.io
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -164,6 +172,10 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - pkg.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+  - secrets.crossplane.io
   resources: ["*"]
   verbs: [get, list, watch]
 ---

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Repository for the Crossplane pod image.
   repository: xpkg.upbound.io/upbound/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`.
-  tag: "v1.15.3-up.1"
+  tag: "v1.15.5-up.1"
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
 

--- a/cluster/olm/bundle/manifests/crossplane_aggregate-to-admin.clusterrole.yaml
+++ b/cluster/olm/bundle/manifests/crossplane_aggregate-to-admin.clusterrole.yaml
@@ -58,6 +58,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/cluster/olm/bundle/manifests/crossplane_aggregate-to-edit.clusterrole.yaml
+++ b/cluster/olm/bundle/manifests/crossplane_aggregate-to-edit.clusterrole.yaml
@@ -48,3 +48,9 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/cluster/olm/bundle/manifests/crossplane_aggregate-to-view.clusterrole.yaml
+++ b/cluster/olm/bundle/manifests/crossplane_aggregate-to-view.clusterrole.yaml
@@ -46,3 +46,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
### Description of your changes

Bumps Upbound's Crossplane to v1.15.5-up.1

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI
