### PR TITLE
[release-1.17] Also mirror uxp chart to spaces-artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Set Crossplane Version
-        run: make crossplane.version > $GITHUB_ENV
+        run: make get-versions > $GITHUB_ENV
 
       - name: Setup Crane
         uses: imjasonh/setup-crane@v0.4
@@ -293,4 +293,6 @@ jobs:
 
       - name: Copy Upbound Crossplane image to Spaces Artifacts Registry
         if: env.XPKG_SPACES_ARTIFACTS_ACCESS_ID != ''
-        run: crane cp xpkg.upbound.io/upbound/crossplane:${CROSSPLANE_VERSION} xpkg.upbound.io/spaces-artifacts/crossplane:${CROSSPLANE_VERSION}
+        run: |
+          crane cp xpkg.upbound.io/upbound/crossplane:${CROSSPLANE_VERSION} xpkg.upbound.io/spaces-artifacts/crossplane:${CROSSPLANE_VERSION}
+          crane cp xpkg.upbound.io/upbound/universal-crossplane:${HELM_CHART_VERSION} xpkg.upbound.io/spaces-artifacts/universal-crossplane:${HELM_CHART_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,9 @@ crossplane:
 	@cat $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/uxp-values.yaml >> $(HELM_CHARTS_DIR)/$(PACKAGE_NAME)/values.yaml
 	@$(OK) Crossplane chart has been fetched
 
-crossplane.version:
+get-versions:
 	@echo CROSSPLANE_VERSION=$(CROSSPLANE_TAG)
+	@echo HELM_CHART_VERSION=$(HELM_CHART_VERSION)
 
 eksaddon.chart: crossplane
 	@$(INFO) Generating values.yaml for the EKS Add-on chart


### PR DESCRIPTION
### Description of your changes

Cherry picks the commit c365a3c32d4f49f218fe64ae35b928af927ecf99 from https://github.com/upbound/universal-crossplane/pull/482

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI
