### PR TITLE
ci: add git credentials for private repos in check-diff job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,15 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Configure Git credentials for private repositories
+        run: |
+          git config --global url."https://upbound-bot:${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}@github.com".insteadOf "https://github.com"
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: true
+          token: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
Configure UPBOUND_BOT_GITHUB_TOKEN for accessing private repositories during the check-diff workflow step.

(cherry picked from commit bc037c8e28ce7cc24725b0a5e596b75ab8b98dfc)

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
