### PR TITLE
ci: migrate AWS auth from IAM access keys to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ env:
   GOLANGCI_VERSION: 'v1.64.8'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # We can't run a step 'if secrets.AWS_ROLE_ARN != ""' but we can run a step
+  # 'if env.AWS_ROLE_ARN != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
   XPKG_SPACES_ARTIFACTS_ACCESS_ID: ${{ secrets.XPKG_SPACES_ARTIFACTS_ACCESS_ID }}
-  AWS_USR: ${{ secrets.AWS_USR }}
+  AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
 
 jobs:
   detect-noop:
@@ -181,6 +181,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Setup QEMU
@@ -249,25 +252,26 @@ jobs:
           username: ${{ secrets.XPKG_ACCESS_ID }}
           password: ${{ secrets.XPKG_TOKEN }}
 
+      - name: Configure AWS Credentials
+        if: env.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Publish Artifacts to S3 and Marketplace
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
-        if: env.AWS_USR != '' && env.XPKG_ACCESS_ID != ''
+        if: env.AWS_ROLE_ARN != '' && env.XPKG_ACCESS_ID != ''
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-          AWS_DEFAULT_REGION: us-east-1
           GIT_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
       - name: Promote Artifacts in S3 and Marketplace
-        if: github.ref == 'refs/heads/main' && env.AWS_USR != '' && env.XPKG_ACCESS_ID != ''
+        if: github.ref == 'refs/heads/main' && env.AWS_ROLE_ARN != '' && env.XPKG_ACCESS_ID != ''
         run: make -j2 promote
         env:
           BRANCH_NAME: main
           CHANNEL: main
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-          AWS_DEFAULT_REGION: us-east-1
 
   mirror-spaces-artifacts:
     runs-on: ubuntu-22.04

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,15 +20,18 @@ on:
         default: false
 
 env:
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # We can't run a step 'if secrets.AWS_ROLE_ARN != ""' but we can run a step
+  # 'if env.AWS_ROLE_ARN != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  AWS_USR: ${{ secrets.AWS_USR }}
+  AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
 
 jobs:
   promote-artifacts:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -54,13 +57,17 @@ jobs:
           username: ${{ secrets.XPKG_ACCESS_ID }}
           password: ${{ secrets.XPKG_TOKEN }}
 
+      - name: Configure AWS Credentials
+        if: env.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Promote Artifacts in S3 and Docker Hub
-        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: env.AWS_ROLE_ARN != '' && env.DOCKER_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
         env:
           VERSION: ${{ github.event.inputs.version }}
           CHANNEL: ${{ github.event.inputs.channel }}
           PRE_RELEASE: ${{ github.event.inputs.pre-release }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-          AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
Replace static AWS_USR/AWS_PSW credentials with OIDC-based authentication using aws-actions/configure-aws-credentials. This eliminates the need for rotating IAM access keys every 90 days.

- Add id-token:write permissions to jobs that need AWS access
- Add Configure AWS Credentials step using role assumption
- Remove hardcoded AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION
- Guard steps on AWS_ROLE_ARN instead of AWS_USR

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
