### PR TITLE
[release-1.20] Update UXP to v1.20.6-up.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.20.5-up.1
-CROSSPLANE_COMMIT := v1.20.5-up.1
+CROSSPLANE_TAG := v1.20.6-up.2
+CROSSPLANE_COMMIT := v1.20.6-up.2
 
 export CROSSPLANE_TAG
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -49,7 +49,7 @@ planes.
 | hostNetwork | bool | `false` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy used for Crossplane and RBAC Manager pods. |
 | image.repository | string | `"xpkg.upbound.io/upbound/crossplane"` | Repository for the Crossplane pod image. |
-| image.tag | string | `"v1.20.5-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
+| image.tag | string | `"v1.20.6-up.2"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
 | imagePullSecrets | list | `[]` | The imagePullSecret names to add to the Crossplane ServiceAccount. |
 | leaderElection | bool | `true` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. |
 | metrics.enabled | bool | `false` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Repository for the Crossplane pod image.
   repository: xpkg.upbound.io/upbound/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`.
-  tag: "v1.20.5-up.1"
+  tag: "v1.20.6-up.2"
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Description of your changes

Bump `CROSSPLANE_TAG` and `CROSSPLANE_COMMIT` to `v1.20.6-up.2` for the upcoming UXP v1.20.6-up.2 security-focused release.

The `-up.2` suffix (rather than `-up.1`) is because the abandoned `v1.20.6-up.1` tag and images from an earlier publish attempt stay orphaned — this release incorporates upbound/crossplane#221 which dropped stray `releases.crossplane.io/*` publish steps that got pulled in via the v1.20.6 sync PR.

What's in the bump compared to `v1.20.5-up.1`:
- Upstream Crossplane v1.20.5 → v1.20.6 (9 upstream PRs: 5 security dep bumps, 3 CI hardening, `crossplane-runtime` → v1.20.6). Details in the sync PR upbound/crossplane#218.
- Fork-only Go toolchain bump from 1.25.6 → 1.25.9 to cover 14 additional stdlib CVEs upstream v1.20.6 hasn't patched yet. upbound/crossplane#220.
- CI workflow cleanup: dropped three `releases.crossplane.io/*` publish steps that shouldn't have been on the fork. upbound/crossplane#221.

Ref upbound/universal-crossplane#528.

### Validation

- `make generate` — succeeded
- `make reviewable` — passed (generate + lint + unit tests all green)

### Reviewer notes

Older-minor (`release-1.20`) patch — PR targets the release branch directly, no backport label.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~