### PR TITLE
[release-1.20] Update Crossplane to v1.20.8-up.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.20.6-up.2
-CROSSPLANE_COMMIT := v1.20.6-up.2
+CROSSPLANE_TAG := v1.20.8-up.1
+CROSSPLANE_COMMIT := v1.20.8-up.1
 
 export CROSSPLANE_TAG
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -49,7 +49,7 @@ planes.
 | hostNetwork | bool | `false` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy used for Crossplane and RBAC Manager pods. |
 | image.repository | string | `"xpkg.upbound.io/upbound/crossplane"` | Repository for the Crossplane pod image. |
-| image.tag | string | `"v1.20.6-up.2"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
+| image.tag | string | `"v1.20.8-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
 | imagePullSecrets | list | `[]` | The imagePullSecret names to add to the Crossplane ServiceAccount. |
 | leaderElection | bool | `true` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. |
 | metrics.enabled | bool | `false` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Repository for the Crossplane pod image.
   repository: xpkg.upbound.io/upbound/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`.
-  tag: "v1.20.6-up.2"
+  tag: "v1.20.8-up.1"
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Overview

Update `CROSSPLANE_TAG` and `CROSSPLANE_COMMIT` to `v1.20.8-up.1` for the v1.20.8-up.1 release. This syncs with upstream Crossplane v1.20.8 which includes crossplane-runtime v1.20.8, Go 1.25.10 (stdlib CVEs), golang.org/x/crypto v0.52.0, and go-git v5.19.1 security fixes.

Ref upbound/universal-crossplane#531

### Validation

`make generate` completed successfully. Chart values and docs updated cleanly.

### Reviewer notes

Version bump PR for the 1.x line, targeting `release-1.20` directly.

---

### Meta information

Ref #531

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a tracking issue to document this change.
- [ ] ~Set the appropriate `kind:[type]` label on the PR.~
- [ ] ~Added release notes if required.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### Release note

```release-note
NONE
```