### PR TITLE
[release-1.20] Update Crossplane to v1.20.10-up.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ EKS_ADDON_REGISTRY := 709825985650.dkr.ecr.us-east-1.amazonaws.com
 CROSSPLANE_REPO := https://github.com/upbound/crossplane.git
 # Tag corresponds to Docker image tag while commit is git-compatible signature
 # for pulling. They do not always match.
-CROSSPLANE_TAG := v1.20.8-up.1
-CROSSPLANE_COMMIT := v1.20.8-up.1
+CROSSPLANE_TAG := v1.20.10-up.1
+CROSSPLANE_COMMIT := v1.20.10-up.1
 
 export CROSSPLANE_TAG
 

--- a/cluster/charts/universal-crossplane/README.md
+++ b/cluster/charts/universal-crossplane/README.md
@@ -49,7 +49,7 @@ planes.
 | hostNetwork | bool | `false` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy used for Crossplane and RBAC Manager pods. |
 | image.repository | string | `"xpkg.upbound.io/upbound/crossplane"` | Repository for the Crossplane pod image. |
-| image.tag | string | `"v1.20.8-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
+| image.tag | string | `"v1.20.10-up.1"` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. |
 | imagePullSecrets | list | `[]` | The imagePullSecret names to add to the Crossplane ServiceAccount. |
 | leaderElection | bool | `true` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. |
 | metrics.enabled | bool | `false` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. |

--- a/cluster/charts/universal-crossplane/values.yaml
+++ b/cluster/charts/universal-crossplane/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Repository for the Crossplane pod image.
   repository: xpkg.upbound.io/upbound/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`.
-  tag: "v1.20.8-up.1"
+  tag: "v1.20.10-up.1"
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Overview

Update `CROSSPLANE_TAG` and `CROSSPLANE_COMMIT` to `v1.20.10-up.1` for the v1.20.10-up.1 UXP release.

Ref #533

### Changes
- Updated `CROSSPLANE_TAG` and `CROSSPLANE_COMMIT` in `Makefile`
- Ran `make generate` to import upstream Helm chart changes

### Validation
- `make generate` completes cleanly

### I have:
- [x] Run `make reviewable`
- [ ] ~Added or updated unit tests~
- [ ] ~Added or updated e2e tests~

```release-note
NONE
```