### PR TITLE
README: clarify location of more information on UXP in Upbound docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Upbound Crossplane (UXP)
 
-> [!NOTE]
-> Looking for the Upbound Crossplane (UXP) repo? See https://github.com/upbound/upbound-crossplane
+> [!IMPORTANT]
+> This repository is deprecated and no longer maintained. UXP is now developed in Upbound's internal
+> repositories. We've kept this repo online for historical reference.
+>
+> To learn more about UXP and get started with deploying and running it, please see the public
+> Upbound docs:
+>
+> https://docs.upbound.io/manuals/uxp/overview/


### PR DESCRIPTION
### Description of your changes

This PR updates the main README file to point to the public UXP docs at https://docs.upbound.io/manuals/uxp/overview/.

The repo that the README is currently pointing at is private, so it's not that useful for visitors coming to this repo out of historical habit.


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I've iterated over the rendered markdown on https://github.com/jbw976/universal-crossplane/blob/readme-deprecation-notice/README.md 